### PR TITLE
[FEAT] add Utils checkValidFileExtension

### DIFF
--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -70,6 +70,7 @@ namespace ft
 	std::string fileToString(std::string file_path);
 	std::string publicFileToString(std::string file_path);
 	Method getMethodType(std::string str);
+	bool checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list);
 }
 
 #endif

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -409,7 +409,7 @@ checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list
 		return (false);
 	tmp = ft::split(file_name, '.');
 	extension = tmp.back();
-	for (int i = 0 ; i < ext_list.size() ; i++)
+	for (size_t i = 0 ; i < ext_list.size() ; i++)
 	{
 		if (ext_list[i].compare(extension) == 0)
 			return (true);

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -399,4 +399,22 @@ getMethodType(std::string str)
 	return (DEFAULT);
 }
 
+bool
+checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list)
+{
+	std::vector<std::string> tmp;
+	std::string extension;
+
+	if (file_name.find(".") == std::string::npos)
+		return (false);
+	tmp = ft::split(file_name, '.');
+	extension = tmp.back();
+	for (int i = 0 ; i < ext_list.size() ; i++)
+	{
+		if (ext_list[i].compare(extension) == 0)
+			return (true);
+	}
+	return (false);
+}
+
 }


### PR DESCRIPTION
확장자 체크 함수

file_name은 말그대로 파일명, ex) `index.html`
ext_list는 확장자가 저장되어 있는 string vector, ex) `ext_list[0] = exe, ext_list[1] = html, ext_list[2] = jpg`

예외처리가 더 필요하면 알려주세요.

```c++
bool
checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list)
{
	std::vector<std::string> tmp;
	std::string extension;

	if (file_name.find(".") == std::string::npos) // file_name에 .이 없으면 false
		return (false);
	tmp = ft::split(file_name, '.'); // file_name을 .으로 split해서 tmp에 배열로 저장
	extension = tmp.back(); // 확장자는 .으로 split 한 것 중 마지막 요소
	for (int i = 0 ; i < ext_list.size() ; i++) // 확장자 리스트 순회
	{
		if (ext_list[i].compare(extension) == 0) // 동일한 확장자를 발견하면
			return (true);  // true 
	}
	return (false); // 순회했는데 없으면 false
}
```