### PR TITLE
[FEAT] add ServerManager (#106)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ SRC =	main.cpp \
 		Request.cpp \
 		Uri.cpp \
 		Utils.cpp \
+		ServerManager.cpp \
+		HttpConfig.cpp \
+		HttpConfigLocation.cpp \
+		HttpConfigServer.cpp \
 
 SRCS = $(addprefix $(DIR_SRC), $(SRC))
 OBJS = $(SRCS:%.cpp=%.o)

--- a/includes/HttpConfigLocation.hpp
+++ b/includes/HttpConfigLocation.hpp
@@ -36,7 +36,7 @@ class HttpConfigLocation
 		static bool checkCommentLine(std::string str);
 
 		/* key func. */
-		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, int &idx);
+		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, size_t &idx);
 };
 
 #endif

--- a/includes/HttpConfigServer.hpp
+++ b/includes/HttpConfigServer.hpp
@@ -29,7 +29,7 @@ class HttpConfigServer
 		/* setter */
 
 		/* key func. */
-		HttpConfigServer& parseServerBlock(std::vector<std::string> lines, int &idx);
+		HttpConfigServer& parseServerBlock(std::vector<std::string> lines, size_t &idx);
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -31,10 +31,18 @@
 **  1. listen(this->m_server_socket, 5) 의 연결 대기열 개수 => 임의로 10개 지정
 **  2. this->m_server_addr.sin_port = htons(PORT);의 PORT => 임의로 #define PORT 3601로 지정
 */
+#include "HttpConfigServer.hpp"
 
 class Server
 {
 	private:
+		HttpConfigServer m_server_block;
+		std::string m_server_name;
+		int m_port;
+		std::string m_err_page_path;
+		size_t m_location_size;
+
+
 		/* Socket */
 		struct sockaddr_in m_server_addr;
 		struct sockaddr_in m_client_addr;
@@ -57,7 +65,13 @@ class Server
 		Server(Server const &other);
 		Server& operator=(Server const &rhs);
 
-		void init();
+		void init(
+			HttpConfigServer server_block,
+			std::string server_name,
+			int port,
+			std::string err_page_path,
+			size_t location_size
+		);
 		void setServerAddr(int port);
 		bool setServerSocket();
 		void runServer();

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -10,21 +10,35 @@
 class ServerManager
 {
 	private:
-		std::string m_ip_address;
-		std::vector<Server> m_server;
 		HttpConfig m_httpConfig;
 
+		std::vector<HttpConfigServer> m_server_block;
+		std::vector<Server> m_server;
+		size_t m_server_size;
+
+		std::string m_software_name;
+		std::string m_software_version;
+		std::string m_mime_include;
+		std::string m_root;
+
 	private:
-		ServerManager(ServerManager const &other);
-		ServerManager& operator=(ServerManager const &rhs);
+		void storeParseValue();
 
 	public:
 		ServerManager();
 		~ServerManager();
+		ServerManager(ServerManager const &other);
+		ServerManager& operator=(ServerManager const &rhs);
 
-		// void checkIPAddress();
 		void parseHttpConfig();
-		Server generateServer(int port);
+		Server generateServer(
+			HttpConfigServer server_block,
+			std::string server_name,
+			int port,
+			std::string err_page_path,
+			size_t location_size
+		);
+		void initServers();
 		void runServers();
 		void exitServers();
 };

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -21,7 +21,12 @@ class ServerManager
 	public:
 		ServerManager();
 		~ServerManager();
-		void checkIPAddress();
+
+		// void checkIPAddress();
+		void parseHttpConfig();
+		Server generateServer(int port);
+		void runServers();
+		void exitServers();
 };
 
 #endif

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -138,7 +138,7 @@ HttpConfig::checkCurlyBracketsDouble(std::string str)
 {
 	int cnt = 0;
 
-	for (int i = 0 ; i < str.size() ; i++)
+	for (size_t i = 0 ; i < str.size() ; i++)
 	{
 		if (str[i] == '{' || str[i] == '}')
 			cnt++;
@@ -151,7 +151,7 @@ HttpConfig::checkCurlyBracketsDouble(std::string str)
 void
 HttpConfig::setConfigFileCheckValid(std::string file_path)
 {
-	int idx = 0;
+	size_t idx = 0;
 
 	this->m_cnt_trash_lines = 0;
 	this->m_file_path = file_path;
@@ -180,7 +180,7 @@ HttpConfig::setConfigFileCheckValid(std::string file_path)
 void
 HttpConfig::parseConfigFile(std::string file_path)
 {
-	int idx = 0;
+	size_t idx = 0;
 	bool server_block_exist = false;
 
 	setConfigFileCheckValid(file_path);
@@ -237,7 +237,7 @@ HttpConfig::printConfigFileInfo()
 		<< dash << std::endl
 		<< std::endl;
 
-	for (int i = 0 ; i < this->m_server_block.size() ; i++)
+	for (size_t i = 0 ; i < this->m_server_block.size() ; i++)
 	{
 		std::cout << dash << std::endl
 			<< "[" << i + 1 << "] server block infomation" << std::endl
@@ -246,17 +246,17 @@ HttpConfig::printConfigFileInfo()
 			<< "default error page : " << this->m_server_block[i].get_m_default_error_page() << std::endl
 			<< "content length : " << this->m_server_block[i].get_m_content_length() << std::endl
 			<< "size of location block : " << this->m_server_block[i].get_m_location_block().size() << std::endl;
-		for (int j = 0 ; j < this->m_server_block[i].get_m_location_block().size() ; j++)
+		for (size_t j = 0 ; j < this->m_server_block[i].get_m_location_block().size() ; j++)
 		{
 			std::cout << "[" << j + 1 << "] location block infomation" << std::endl
 				<< "path : " << this->m_server_block[i].get_m_location_block()[j].get_m_path() << std::endl
 				<< "root : " << this->m_server_block[i].get_m_location_block()[j].get_m_root() << std::endl
 				<< "index : ";
-			for (int k = 0 ; k < this->m_server_block[i].get_m_location_block()[j].get_m_index().size() ; k++)
+			for (size_t k = 0 ; k < this->m_server_block[i].get_m_location_block()[j].get_m_index().size() ; k++)
 				std::cout << this->m_server_block[i].get_m_location_block()[j].get_m_index()[k] << " ";
 			std::cout << std::endl;
 			std::cout << "cgi : ";
-			for (int k = 0 ; k < this->m_server_block[i].get_m_location_block()[j].get_m_cgi().size() ; k++)
+			for (size_t k = 0 ; k < this->m_server_block[i].get_m_location_block()[j].get_m_cgi().size() ; k++)
 				std::cout << this->m_server_block[i].get_m_location_block()[j].get_m_cgi()[k] << " ";
 			std::cout << std::endl
 				<< "cgi path : " << this->m_server_block[i].get_m_location_block()[j].get_m_cgi_path() << std::endl

--- a/srcs/HttpConfigLocation.cpp
+++ b/srcs/HttpConfigLocation.cpp
@@ -113,7 +113,7 @@ HttpConfigLocation::checkCommentLine(std::string str)
 }
 
 HttpConfigLocation&
-HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, int &idx)
+HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, size_t &idx)
 {
 	while (42)
 	{
@@ -124,7 +124,7 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, int &idx)
 			line.pop_back();
 		if (line.front().compare("location") == 0)
 		{
-			for (int i = 1 ; i < line.size() ; i++)
+			for (size_t i = 1 ; i < line.size() ; i++)
 			{
 				if (line.empty())
 					continue ;
@@ -134,7 +134,7 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, int &idx)
 		}
 		else if (line.front().compare("limit_except") == 0)
 		{
-			for (int i = 1 ; i < line.size() ; i++)
+			for (size_t i = 1 ; i < line.size() ; i++)
 			{
 				if (line[i].empty())
 					continue ;
@@ -146,7 +146,7 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, int &idx)
 		else if (line.front().compare("index") == 0)
 		{
 
-			for (int i = 1 ; i < line.size() ; i++)
+			for (size_t i = 1 ; i < line.size() ; i++)
 			{
 				if (line[i].empty())
 					continue ;
@@ -156,7 +156,7 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, int &idx)
 		}
 		else if (line.front().compare("cgi") == 0)
 		{
-			for (int i = 1 ; i < line.size() ; i++)
+			for (size_t i = 1 ; i < line.size() ; i++)
 			{
 				if (line[i].empty())
 					continue ;

--- a/srcs/HttpConfigServer.cpp
+++ b/srcs/HttpConfigServer.cpp
@@ -90,7 +90,7 @@ HttpConfigServer::get_m_location_block() const
 /*============================================================================*/
 
 HttpConfigServer&
-HttpConfigServer::parseServerBlock(std::vector<std::string> lines, int &idx)
+HttpConfigServer::parseServerBlock(std::vector<std::string> lines, size_t &idx)
 {
 	bool location_block_exist = false;
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -57,14 +57,17 @@ char *bin2hex(const unsigned char *input, size_t len)
 */
 
 void
-Server::init()
+Server::init(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, size_t location_size)
 {
 	this->m_requests = std::vector<Request>(MAX_SOCK_NUM);
 	this->m_responses = std::vector<Response>(MAX_SOCK_NUM);
+	this->m_server_block = server_block;
+	this->m_server_name = server_name;
+	this->m_port = port;
+	this->m_err_page_path = err_page_path;
+	this->m_location_size = location_size;
+	return ;
 }
-
-
-
 
 /*
 **	struct sockaddr_in {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -7,6 +7,26 @@
 
 Server::Server(){};
 Server::~Server(){};
+Server::Server(Server const &other)
+{
+	*this = other;
+};
+Server& Server::operator=(Server const &rhs)
+{
+	m_server_addr = rhs.m_server_addr;
+	m_client_addr = rhs.m_client_addr;
+	m_server_socket = rhs.m_server_socket;
+	m_client_socket = rhs.m_client_socket;
+	fd_num = rhs.fd_num;
+	sockfd = rhs.sockfd;
+	readn = rhs.readn;
+	maxfd = rhs.maxfd;
+	m_main_fds = rhs.m_main_fds;
+	m_copy_fds = rhs.m_copy_fds;
+	m_requests = rhs.m_requests;
+	m_responses = rhs.m_responses;
+	return (*this);
+};
 
 char *bin2hex(const unsigned char *input, size_t len)
 {

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -1,0 +1,35 @@
+#include "ServerManager.hpp"
+
+ServerManager::ServerManager(){};
+ServerManager::~ServerManager(){};
+
+void
+ServerManager::parseHttpConfig()
+{
+	this->m_httpConfig.setConfigFileCheckValid("ftinx_sample.conf");
+	return ;
+}
+
+Server
+ServerManager::generateServer(int port)
+{
+	Server server;
+	server.init();
+	server.setServerAddr(port);
+	server.setServerSocket();
+	server.runServer();
+	return (server);
+}
+
+void
+ServerManager::runServers()
+{
+	this->m_server.push_back(generateServer(3601));
+	return ;
+}
+
+void
+ServerManager::exitServers()
+{
+	return ;
+}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -2,29 +2,81 @@
 
 ServerManager::ServerManager(){};
 ServerManager::~ServerManager(){};
+ServerManager::ServerManager(ServerManager const &other)
+{
+	*this = other;
+};
+ServerManager& ServerManager::operator=(ServerManager const &rhs)
+{
+	m_httpConfig = rhs.m_httpConfig;
+
+	m_server_block = rhs.m_server_block;
+	m_server = rhs.m_server;
+	m_server_size = rhs.m_server_size;
+
+	m_software_name = rhs.m_software_name;
+	m_software_version = rhs.m_software_version;
+	m_mime_include = rhs.m_mime_include;
+	m_root = rhs.m_root;
+	return (*this);
+};
+
+void
+ServerManager::storeParseValue()
+{
+	this->m_software_name = this->m_httpConfig.get_m_name();
+	this->m_software_version = this->m_httpConfig.get_m_version();
+	this->m_mime_include = this->m_httpConfig.get_m_include();
+	this->m_root = this->m_httpConfig.get_m_root();
+	this->m_server_size = this->m_httpConfig.get_m_server_block().size();
+	this->m_server_block = this->m_httpConfig.get_m_server_block();
+	return ;
+}
 
 void
 ServerManager::parseHttpConfig()
 {
 	this->m_httpConfig.setConfigFileCheckValid("ftinx_sample.conf");
+	this->m_httpConfig.parseConfigFile("ftinx_sample.conf");
+	this->m_httpConfig.printConfigFileInfo();
+
+	storeParseValue();
 	return ;
 }
 
 Server
-ServerManager::generateServer(int port)
+ServerManager::generateServer(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, size_t location_size)
 {
 	Server server;
-	server.init();
+	server.init(server_block, server_name, port, err_page_path, location_size);
 	server.setServerAddr(port);
 	server.setServerSocket();
-	server.runServer();
 	return (server);
+}
+
+void
+ServerManager::initServers()
+{
+	for (size_t i = 0; i < m_server_size; i++) {
+		this->m_server.push_back(
+			generateServer(
+				this->m_server_block[i],
+				this->m_server_block[i].get_m_server_name(),
+				this->m_server_block[i].get_m_listen(),
+				this->m_server_block[i].get_m_default_error_page(),
+				this->m_server_block[i].get_m_location_block().size()
+			)
+		);
+	}
+	return ;
 }
 
 void
 ServerManager::runServers()
 {
-	this->m_server.push_back(generateServer(3601));
+	for (size_t i = 0; i < m_server_size; i++) {
+		this->m_server[i].runServer();
+	}
 	return ;
 }
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,43 +1,19 @@
-#include "Server.hpp"
-#include "Response.hpp"
-#include "Request.hpp"
-#include "fcntl.h"
-#include <string>
+#include "ServerManager.hpp"
 #include <iostream>
-
-#define BUFFER_SIZE 4096
-std::string fileToString(std::string file_path)
-{
-	int fd;
-	int bytes;
-	char buffer[BUFFER_SIZE];
-	std::string ret;
-	if ((fd = open(file_path.c_str(), O_RDONLY)) < 0)
-		throw std::exception();
-	memset(buffer, 0, BUFFER_SIZE);
-	while ((bytes = read(fd, buffer, BUFFER_SIZE) > 0))
-		ret += std::string(buffer);
-	if (bytes < 0)
-		throw std::exception();
-	return (ret);
-}
 
 int
 main()
 {
-	Server server = Server();
+	ServerManager serverManager;
 
-	server.init();
-	server.setServerAddr(3601);
-	server.setServerSocket();
-	server.runServer();
-
-	// std::string message = fileToString("./request_msg.txt");
-	// Request request;
-	// request.parseMessage(message);
-
-	// std::cout << request << std::endl;
-	// request.printHeaders();
-
+	try
+	{
+		serverManager.parseHttpConfig();
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << std::endl;
+	}
+	serverManager.runServers();
 	return (EXIT_SUCCESS);
 }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -9,6 +9,7 @@ main()
 	try
 	{
 		serverManager.parseHttpConfig();
+		serverManager.initServers();
 	}
 	catch (const std::exception& e)
 	{


### PR DESCRIPTION
#103 
1. ServerManager를 합치면서 vector.size()를 int와 비교해서 오류 발생
- __solve__: 모두 size_t로 바꾸었으나 size_t로 바꾸는것도 좋은 방법은 아니라고한다.
```
srcs/HttpConfig.cpp:240:21: error: comparison of integers of different signs:
      'int' and 'std::__1::vector<HttpConfigServer,
      std::__1::allocator<HttpConfigServer> >::size_type' (aka 'unsigned long')
      [-Werror,-Wsign-compare]
```
2.  config에 설정된 서버 개수만큼 서버 실행
- 8080, 8081 모두 잘 실행된다.

3. Config파일에따른 Server, ServerManager class 변수 및 함수 추가.

---
- 다음에 진행할 사항

config 파일 설정에 따라 server에서 다음 요청을 처리할 수 있도록 동적으로 생성해야한다.  
동적으로 생성하게 만들 예정.

```
        location / {
            limit_except GET;
            cgi .bin .cgi .bla;
            cgi_path /Users/holee/Documents/Webserv/cgi_tester;
			index index.html;
            root /Users/holee/Documents/Webserv/;
        }
```


