### PR TITLE
[FIX] getDateTimestamp err #112

### DIFF
--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -306,12 +306,13 @@ getDateTimestamp(int hour, int minute, int second)
 	struct timeval currentTime;
 	struct tm *tm;
 	char buf[64];
+	int ret;
 
 	gettimeofday(&currentTime, NULL);
 	currentTime.tv_sec += 3600 * hour + 60 * minute + second;
 	tm = localtime(&currentTime.tv_sec);
-	strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %Z", tm);
-	free(tm);
+	ret = strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %Z", tm);
+	buf[ret] = '\0';
 	return (buf);
 }
 


### PR DESCRIPTION
1. free 하면 안되는듯

> The pointer returned by localtime (and some other functions) are actually pointers to statically allocated memory. So you do not need to free it, and you should not free it.

- https://stackoverflow.com/questions/8694365/how-is-the-result-struct-of-localtime-allocated-in-c

2. buf 마지막에 null 추가