### PR TITLE
[FEAT] add route path, post

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -86,10 +86,10 @@ class Server
 
 		/* SERVER METHOD UTIL */
 		static Response getDirectory();
+		static Response postAuth(Request req);
 
-		// static Response getDirectory();
 		Response get(std::string path, Request req, Response res, Response (*func)());
-		Response post(std::string path, Request req, Response res, Response (*func)());
+		Response post(std::string path, Request req, Response res, Response (*func)(Request req));
 		Response put(std::string path, Request req, Response res, Response (*func)());
 		Response del(std::string path, Request req, Response res, Response (*func)());
 		Response update(std::string path, Request req, Response res, Response (*func)());
@@ -106,17 +106,16 @@ class Server
 		Response methodTRACE(int clientfd);
 
 		Response OptionsPathRoot();
-		std::map<std::string, std::string> parseQuery(std::string str);
-		Response post_200();
+		static std::map<std::string, std::string> parseQuery(std::string str);
+		static Response post_200();
 
 		char** makeCgiEnvp(int clientfd);
 		Response executeCgi(int clientfd);
-		Response postCGI(int clientfd);
 
 		// Response continue_100();
 		// Response switchingProtocols_101();
 
-		Response page200();
+		static Response page200();
 		// Response created_201();
 		// Response Accepted_202();
 		// Response nonAuthoritativeInformation_203();
@@ -132,12 +131,12 @@ class Server
 		// Response useProxy_305();
 		// Response temporaryRedirect_307();
 
-		Response badRequest_400();
+		static Response badRequest_400();
 		// Response unauthorized_401();
 		// Response paymentRequired_402();
 		// Response forbidden_403();
-		Response page404();
-		Response methodNotAllow_405();
+		static Response page404();
+		static Response methodNotAllow_405();
 		// Response notAcceptable_406();
 		// Response proxyAuthenticationRequired_407();
 		// Response requestTimeout_408();
@@ -153,7 +152,7 @@ class Server
 		// Response upgradeRequired_426();
 
 		// Response internalServerError_500();
-		Response methodNotImplemented_501();
+		static Response methodNotImplemented_501();
 		// Response badGateWay_502();
 		// Response serviceUnavailble_503();
 		// Response gatewayTimeout_504();

--- a/srcs/Uri.cpp
+++ b/srcs/Uri.cpp
@@ -124,7 +124,7 @@ Uri::parseUri()
     {
         this->m_scheme = "http";
         this->m_check_abs_uri = false;
-        return (parsePath(this->m_uri.substr(1, std::string::npos)));
+        return (parsePath(this->m_uri.substr(0, std::string::npos)));
     }
     this->m_scheme = this->m_uri.substr(0, scheme_pos);
     return (this->parseHostPort(this->m_uri.substr(scheme_pos + 3, std::string::npos)));

--- a/www/index.html
+++ b/www/index.html
@@ -19,7 +19,7 @@
 
 	<!-- form -->
 	<form
-		action="http://localhost:3601/auth"
+		action="http://localhost:8080/auth"
 		accept-charset="utf-8"
 		method="post"
 		class="signupForm"
@@ -56,7 +56,7 @@
 	<!-- TRACE -->
 	<div class="indexContainer">
 		<h1>Trace</h1>
-		<p>curl -v -X TRACE 127.0.0.1:3601</p>
+		<p>curl -v -X TRACE 127.0.0.1:8080</p>
 	</div>
 
 	<!-- CGI -->


### PR DESCRIPTION
### 변경사항

1. 이제 Response page를 부를때 Static 으로 불러야합니다.

- 변경 전
```c++
return (page200());
```


- 변경 후
```c++
return (Server::page200());
```

2. 로직을 단순화 할 수 있습니다. 

- 변경 전
```c++
Response
Server::methodPOST(int clientfd)
{
	std::string path = this->m_requests[clientfd].get_m_uri().get_m_path();
	std::map<std::string, std::string> m_query = parseQuery(this->m_requests[clientfd].get_m_body());
	std::string username;
	std::string password;

	if (path == "/auth")
	{
		if(m_query.find("formType") != m_query.end()
		&& m_query.find("formType")->second == "login")
		{
			username = m_query.find("username")->second;
			password = m_query.find("password")->second;

			printf("::%s:: ::%s::", username.c_str(), password.c_str());
			printf("::%d:: ::%d::", username == "42seoul", password == "42seoul");

			if (username == "42seoul" && password == "42seoul")
				return (post_200());
			else
				return (page200());
		}
	}
	return (page404());
}
```

- 변경 후
```c++
Response
Server::postAuth(Request req)
{
	std::string path = req.get_m_uri().get_m_path();
	std::map<std::string, std::string> m_query = Server::parseQuery(req.get_m_body());
	std::string username;
	std::string password;

	if (path == "/auth")
	{
		if(m_query.find("formType") != m_query.end()
		&& m_query.find("formType")->second == "login")
		{
			username = m_query.find("username")->second;
			password = m_query.find("password")->second;

			printf("::%s:: ::%s::", username.c_str(), password.c_str());
			printf("::%d:: ::%d::", username == "42seoul", password == "42seoul");

			if (username == "42seoul" && password == "42seoul")
				return (Server::post_200());
			else
				return (Server::page200());
		}
	}
	return (Server::page404());
}

Response
Server::methodPOST(int clientfd)
{
	Response response;

	response = post("/auth", this->m_requests[clientfd], response, Server::postAuth);
	return (response);
}
```