### PR TITLE
[FEAT] add HttpConfig* checkFileExist, checkDirExist #109

### DIFF
--- a/includes/HttpConfig.hpp
+++ b/includes/HttpConfig.hpp
@@ -17,6 +17,7 @@ class HttpConfig
 		std::string m_config_file; // config file -> string
 		std::vector<std::string> m_lines; // m_config_file -> split lines(\n)
 		int m_cnt_trash_lines; // for debug
+		//int m_error_line;
 
 		std::string m_name;
 		std::string m_version;

--- a/includes/HttpConfigLocation.hpp
+++ b/includes/HttpConfigLocation.hpp
@@ -34,6 +34,15 @@ class HttpConfigLocation
 
 		/* utils */
 		static bool checkCommentLine(std::string str);
+		static void checkDirExist(std::string path);
+		static void checkFileExist(std::string root, std::string path);
+
+		/* exceptions */
+		class parseErrorException : public std::exception
+		{
+			public:
+				virtual const char *what() const throw();
+		};
 
 		/* key func. */
 		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, size_t &idx);

--- a/includes/HttpConfigServer.hpp
+++ b/includes/HttpConfigServer.hpp
@@ -29,7 +29,7 @@ class HttpConfigServer
 		/* setter */
 
 		/* key func. */
-		HttpConfigServer& parseServerBlock(std::vector<std::string> lines, size_t &idx);
+		HttpConfigServer& parseServerBlock(std::vector<std::string> lines, std::string root, size_t &idx);
 };
 
 #endif

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -6,20 +6,15 @@
 
 HttpConfig::HttpConfig()
 :
-	m_name(),
-	m_version(),
-	m_include(),
-	m_root(),
+	m_name(""),
+	m_version(""),
+	m_include(""),
+	m_root(""),
 	m_server_block()
 {
 }
 
-HttpConfig::HttpConfig(HttpConfig const &other):
-	m_name(),
-	m_version(),
-	m_include(),
-	m_root(),
-	m_server_block()
+HttpConfig::HttpConfig(HttpConfig const &other)
 {
 	*this = other;
 }
@@ -198,12 +193,15 @@ HttpConfig::parseConfigFile(std::string file_path)
 		else if (line.front().compare("include") == 0)
 			this->m_include = line.back();
 		else if (line.front().compare("root") == 0)
+		{
+			// HttpConfigLocation::checkDirExist(line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
 			this->m_root = line.back();
+		}
 		else if (line.front().compare("server") == 0)
 		{
 			server_block_exist = true;
 			HttpConfigServer server = HttpConfigServer();
-			this->m_server_block.push_back(server.parseServerBlock(this->m_lines, idx));
+			this->m_server_block.push_back(server.parseServerBlock(this->m_lines, this->m_root, idx));
 			continue ;
 		}
 		else if (line.front().compare("}") == 0)

--- a/srcs/HttpConfigServer.cpp
+++ b/srcs/HttpConfigServer.cpp
@@ -5,21 +5,16 @@
 /*============================================================================*/
 
 HttpConfigServer::HttpConfigServer():
-	m_server_name(),
-	m_listen(),
-	m_default_error_page(),
-	m_content_length(),
+	m_server_name(""),
+	m_listen(0),
+	m_default_error_page(""),
+	m_content_length(0),
 	m_location_block()
 {
 
 }
 
-HttpConfigServer::HttpConfigServer(HttpConfigServer const &other):
-	m_server_name(),
-	m_listen(),
-	m_default_error_page(),
-	m_content_length(),
-	m_location_block()
+HttpConfigServer::HttpConfigServer(HttpConfigServer const &other)
 {
 	*this = other;
 }
@@ -90,7 +85,7 @@ HttpConfigServer::get_m_location_block() const
 /*============================================================================*/
 
 HttpConfigServer&
-HttpConfigServer::parseServerBlock(std::vector<std::string> lines, size_t &idx)
+HttpConfigServer::parseServerBlock(std::vector<std::string> lines, std::string root, size_t &idx)
 {
 	bool location_block_exist = false;
 
@@ -106,7 +101,10 @@ HttpConfigServer::parseServerBlock(std::vector<std::string> lines, size_t &idx)
 		else if (line.front().compare("listen") == 0)
 			this->m_listen = stoi(line.back());
 		else if (line.front().compare("default_error_page") == 0)
+		{
+			// HttpConfigLocation::checkFileExist(root, line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
 			this->m_default_error_page = line.back();
+		}
 		else if (line.front().compare("content_length") == 0)
 			this->m_content_length = stoi(line.back());
 		else if (line.front().compare("location") == 0)


### PR DESCRIPTION
http block의 root,
server block의 default error page,
location block의 root, cgi path

파일 또는 폴더가 존재하는지 여부 유효성 체크 추가
서로 다른 pc에서 같은 config 파일로 테스트를 해야하기 때문에 절대 경로를 계속 바꾸는 번거로움을 줄이기 위해
추가만 하고 작동하지 않도록 해당 라인들 주석처리 함