### PR TITLE
[FEAT] add getMethod

### DIFF
--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -371,12 +371,13 @@ Server::getRequest()
 /*********************************  HEAD  *************************************/
 /*============================================================================*/
 
-// Response
-// Server::methodHEAD(int clientfd)
-// {
-
-// 	}
-// }
+Response
+Server::methodHEAD(int clientfd)
+{
+	Response response;
+	clientfd=0;
+	return (response);
+}
 
 /*============================================================================*/
 /**********************************  GET  *************************************/
@@ -388,22 +389,36 @@ Server::methodGET(int clientfd)
 	Response response;
 	std::string path = this->m_requests[clientfd].get_m_uri().get_m_path();
 
-	if (ft::isValidFilePath(path) == false)
-		return (Server::page404("errors/default_error.html"));
-	else
-	{
+	std::cout << "path!!!!!!!!!!!!!!: " << path << std::endl;
+	std::cout << "^^^^^^^^^^^^" << this->m_requests[clientfd].getContentType() << std::endl;
+	if (this->m_requests[clientfd].getContentType().compare("text/html"))
 		return (
 			response
 				.setPublicFileDocument(path)
-				.setHttpResponseHeader("date", response.get_m_date())
-				.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
-				.setHttpResponseHeader("content-language", response.get_m_content_language())
-				.setHttpResponseHeader("content-type", response.get_m_content_type())
-				.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
-				.setHttpResponseHeader("server", response.get_m_server())
 				.makeHttpResponseMessage()
 		);
-}
+	else
+		return (
+			response
+				.setPublicFileDocument("index.html")
+				.makeHttpResponseMessage()
+		);
+	// if (ft::isValidFilePath(path) == false)
+	// 	return (Server::page404("errors/default_error.html"));
+	// else
+	// {
+	// 	return (
+	// 		response
+	// 			.setPublicFileDocument(path)
+	// 			.setHttpResponseHeader("date", response.get_m_date())
+	// 			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
+	// 			.setHttpResponseHeader("content-language", response.get_m_content_language())
+	// 			.setHttpResponseHeader("content-type", response.get_m_content_type())
+	// 			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
+	// 			.setHttpResponseHeader("server", response.get_m_server())
+	// 			.makeHttpResponseMessage()
+	// 	);
+	// }
 }
 
 /*============================================================================*/

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -70,9 +70,9 @@ ServerManager::storeParseValue()
 void
 ServerManager::parseHttpConfig()
 {
-	this->m_httpConfig.setConfigFileCheckValid("ftinx_sample.conf");
+	// this->m_httpConfig.setConfigFileCheckValid("ftinx_sample.conf");
 	this->m_httpConfig.parseConfigFile("ftinx_sample.conf");
-	this->m_httpConfig.printConfigFileInfo();
+	// this->m_httpConfig.printConfigFileInfo();
 
 	storeParseValue();
 	return ;


### PR DESCRIPTION
getMethod

파일이 요청되면
1. 경로에 위치하는지 확인 -> 반환
2. 로케이션 블록 path 순회하며 일치하면 -> index vector 순회하며 있는 파일 반환
3. 1,2 아니면 404 반환

문제
- 헤더 없이 파일 반환만 테스트중
- 1,2,3 모두 정상 작동하지만 fd_zero 활성화 시켜도 여러번 get 요청이 되지 않음
- server manager에서 http block의 root 값을 넘겨줘야 함, 파일이 경로에 위치하는지 확인할 때 필요
- setPublicFileDocument 문제 -> #137

