### PR TITLE
[FEAT] add makeResponseMessage, server

### DIFF
--- a/ftinx_sample_holee.conf
+++ b/ftinx_sample_holee.conf
@@ -1,0 +1,56 @@
+http {
+    software_name ftinx #프로그램명
+    software_version 0.1 #버전
+    include mime.types
+    root /Users/ftinx/Webserv/
+#서버블록 시작
+    server {
+        server_name first_server
+        listen 8080
+        default_error_page ./www/errors/default_error.html
+        content_length 2048
+        location / {
+            limit_except GET
+            cgi .bin .cgi .bla
+            cgi_path /Users/holee/Documents/Webserv/cgi_tester
+            index index.html
+            root /Users/holee/Desktop/webserv
+            autoindex on
+        }
+        location /put_test {
+            limit_except PUT
+            root /Users/holee/Documents/Webserv/tests/put_test
+            cgi .bla
+            cgi_path /Users/holee/Desktop/webserv/cgi_tester
+        }
+        location /post_body {
+            limit_client_body_size 100
+            limit_except POST
+            index index.html
+            root /Users/holee/Desktop/webserv/tests/folder
+        }
+        location /directory {
+            limit_except GET POST
+            index youpi.bad_extension
+            cgi .bla .php
+            cgi_path /Users/holee/Desktop/webserv/YoupiBanane/youpi.bad_extension
+            root /Users/holee/Desktop/webserv/YoupiBanane
+        }
+    }
+#첫번째 서버블록 끝, 두번째 서버블록 시작
+    server {
+        server_name second_server
+        listen       8081
+        location /first {
+            index  index.html index.htm
+        }
+
+        location /second {
+            root /Users/holee/Documents/dev/team_webserv/tests/
+            index  html
+            limit_except PUT POST GET OPTIONS
+            index index.html index.htm index.abc
+        }
+    }
+#서버블록 끝
+}

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -90,9 +90,9 @@ class Response
 		void set_m_cgi_client_addr(in_addr_t cgi_client_addr);
 		void set_m_cgi_server_name(std::string cgi_server_name);
 		void set_m_cgi_port(int cgi_port);
-		void get_m_cgi_extension(std::vector<std::string> cgi_extension);
-		void get_m_index_file(std::vector<std::string> index_file);
-		void get_m_root(std::string root);
+		void set_m_cgi_extension(std::vector<std::string> cgi_extension);
+		void set_m_index_file(std::vector<std::string> index_file);
+		void set_m_root(std::string root);
 
 		/* CGI */
 		bool parseCgiResponse(std::string&);

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -48,11 +48,14 @@ class Response
 		int m_response_size;
 
 		/* Config */
+		std::vector<std::string> m_index_file;
 		std::string m_err_page_path;
+		std::string m_root;
 
 		/* CGI */
-		in_addr_t m_cgi_client_addr;
+		std::vector<std::string> m_cgi_extension;
 		std::string m_cgi_server_name;
+		in_addr_t m_cgi_client_addr;
 		int m_cgi_port;
 
 	public:
@@ -76,6 +79,9 @@ class Response
 		in_addr_t get_m_cgi_client_addr() const;
 		std::string get_m_cgi_server_name() const;
 		int get_m_cgi_port() const;
+		std::vector<std::string> get_m_cgi_extension() const;
+		std::vector<std::string> get_m_index_file() const;
+		std::string get_m_root() const;
 
 		/* setter */
 		void set_m_status_code(int statusCode);
@@ -84,6 +90,9 @@ class Response
 		void set_m_cgi_client_addr(in_addr_t cgi_client_addr);
 		void set_m_cgi_server_name(std::string cgi_server_name);
 		void set_m_cgi_port(int cgi_port);
+		void get_m_cgi_extension(std::vector<std::string> cgi_extension);
+		void get_m_index_file(std::vector<std::string> index_file);
+		void get_m_root(std::string root);
 
 		/* CGI */
 		bool parseCgiResponse(std::string&);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -105,6 +105,7 @@ class Server
 		static Response postLoginSuccess();
 		static Response postAuth(Request req, Response res);
 		static std::map<std::string, std::string> parseQuery(std::string str);
+		static Response HttpConfigPost(Request req, Response res);
 
 		static std::map<std::string, std::string> makeCgiEnvpMap(Request req, Response res);
 		static char** makeCgiEnvp(Request req, Response res);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -97,7 +97,7 @@ class Server
 		Response parseErrorResponse(int clientfd);
 
 		/* SERVER METHOD UTIL */
-		static Response getDirectory();
+		static Response getDirectory(Request req, Response res);
 		static Response postLoginSuccess();
 		static Response postAuth(Request req, Response res);
 		static std::map<std::string, std::string> parseQuery(std::string str);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -97,12 +97,17 @@ class Server
 		void closeServer();
 
 		void getRequest();
+		static Response makeResponseMessage(
+			int statusCode,
+			std::string path = "./www/index.html", std::string contentType="text/html; charset=UTF-8",
+			int dateHour=0, int dateMinute=0, int dateSecond=0,
+			std::string contentLanguage="ko, en", std::string server="ftnix/1.0 (MacOS)"
+		);
 		void sendResponse(int clientfd);
 		Response parseErrorResponse(int clientfd);
 
 		/* SERVER METHOD UTIL */
 		static Response getDirectory(Request req, Response res);
-		static Response postLoginSuccess();
 		static Response postAuth(Request req, Response res);
 		static std::map<std::string, std::string> parseQuery(std::string str);
 		static Response HttpConfigPost(Request req, Response res);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -69,6 +69,7 @@ class Server
 		std::string get_m_server_name();
 		int get_m_port();
 
+		void noteCGILocation();
 		void init(
 			HttpConfigServer server_block,
 			std::string server_name,

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -15,6 +15,7 @@
 #include "Response.hpp"
 #include "Request.hpp"
 #include "HttpConfig.hpp"
+#include "HttpConfigLocation.hpp"
 #include "Utils.hpp"
 
 #define MAX_SOCK_NUM 1024
@@ -37,6 +38,7 @@
 class Server
 {
 	private:
+		/* Config */
 		HttpConfigServer m_server_block;
 		std::string m_server_name;
 		int m_port;
@@ -44,10 +46,17 @@ class Server
 		int m_content_length;
 		size_t m_location_size;
 
+		/* Parse */
+		std::vector<HttpConfigLocation> m_getLocation;
+		std::vector<HttpConfigLocation> m_postLocation;
+		std::vector<HttpConfigLocation> m_putLocation;
+		std::vector<HttpConfigLocation> m_deleteLocation;
+		std::vector<HttpConfigLocation> m_optionsLocation;
+		std::vector<HttpConfigLocation> m_traceLocation;
+
 		/* Socket */
 		struct sockaddr_in m_server_addr;
 		struct sockaddr_in m_client_addr;
-		// socklen_t addrlen;
 		int m_server_socket;
 		int m_client_socket;
 		int fd_num;

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -100,7 +100,6 @@ class Server
 		Response post(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
 		Response put(std::string path, Request req, Response res, Response (*func)());
 		Response del(std::string path, Request req, Response res, Response (*func)());
-		Response update(std::string path, Request req, Response res, Response (*func)());
 		Response options(std::string path, Request req, Response res, Response (*func)());
 		Response trace(std::string path, Request req, Response res, Response (*func)());
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -75,10 +75,14 @@ class Server
 		Server(Server const &other);
 		Server& operator=(Server const &rhs);
 
+		/* getter */
 		std::string get_m_server_name();
 		int get_m_port();
+		std::vector<HttpConfigLocation> get_m_postLocation();
 
-		void noteCGILocation();
+		/* setter */
+
+		void noteHttpConfigLocation();
 		void init(
 			HttpConfigServer server_block,
 			std::string server_name,

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -45,6 +45,7 @@ class Server
 		std::string m_err_page_path;
 		int m_content_length;
 		size_t m_location_size;
+		std::string m_root;
 
 		/* Parse */
 		std::vector<HttpConfigLocation> m_getLocation;
@@ -89,7 +90,8 @@ class Server
 			int port,
 			std::string err_page_path,
 			int content_length,
-			size_t location_size
+			size_t location_size,
+			std::string root
 		);
 		void setServerAddr(int port);
 		bool setServerSocket();

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -96,12 +96,12 @@ class Server
 		static char** makeCgiEnvp(Request req, Response res);
 		static Response executeCgi(Request req, Response res);
 
-		Response get(std::string path, Request req, Response res, Response (*func)());
+		Response get(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
 		Response post(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
-		Response put(std::string path, Request req, Response res, Response (*func)());
-		Response del(std::string path, Request req, Response res, Response (*func)());
-		Response options(std::string path, Request req, Response res, Response (*func)());
-		Response trace(std::string path, Request req, Response res, Response (*func)());
+		Response put(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
+		Response del(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
+		Response options(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
+		Response trace(std::string path, Request req, Response res, Response (*func)(Request req, Response res));
 
 		/* METHOD */
 		Response methodHEAD(int clientfd);

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -37,7 +37,8 @@ class ServerManager
 			int port,
 			std::string err_page_path,
 			int content_length,
-			size_t location_size
+			size_t location_size,
+			std::string root
 		);
 		void initServers();
 		void runServers();

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -13,7 +13,7 @@ class ServerManager
 		HttpConfig m_httpConfig;
 
 		std::vector<HttpConfigServer> m_server_block;
-		std::vector<Server> m_server;
+		std::vector<Server*> m_server;
 		size_t m_server_size;
 
 		std::string m_software_name;

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -12,7 +12,7 @@ Response::Response()
 :m_status_code(404), m_date(""), m_content_language("ko, en"), m_content_type("text/html; charset=UTF-8"),
 m_server("ftnix/1.0 (MacOS)"), m_status_description(""), m_headers(), m_html_document(""), m_body(""),
 m_head(""), m_content_length(0), m_response_message(""), m_response_size(0), m_err_page_path("errors/default_error.html"),
-m_cgi_client_addr(), m_cgi_server_name(""), m_cgi_port(0)
+m_cgi_client_addr(), m_cgi_server_name(""), m_cgi_port(0), m_index_file(), m_root(""), m_cgi_extension()
 {
 }
 
@@ -24,31 +24,34 @@ Response::Response(Response const &other)
 Response &
 Response::operator=(Response const &rhs)
 {
-	m_status_code = rhs.m_status_code;
-	m_date = rhs.m_date;
-	m_content_language = rhs.m_content_language;
-	m_content_type = rhs.m_content_type;
-	m_server = rhs.m_server;
-	m_status_description = rhs.m_status_description;
+	this->m_status_code = rhs.m_status_code;
+	this->m_date = rhs.m_date;
+	this->m_content_language = rhs.m_content_language;
+	this->m_content_type = rhs.m_content_type;
+	this->m_server = rhs.m_server;
+	this->m_status_description = rhs.m_status_description;
 
 	/* HTML document */
-	m_headers = rhs.m_headers;
-	m_html_document = rhs.m_html_document;
-	m_body = rhs.m_body;
-	m_head = rhs.m_head;
-	m_content_length = rhs.m_content_length;
+	this->m_headers = rhs.m_headers;
+	this->m_html_document = rhs.m_html_document;
+	this->m_body = rhs.m_body;
+	this->m_head = rhs.m_head;
+	this->m_content_length = rhs.m_content_length;
 
 	/* response message */
-	m_response_message = rhs.m_response_message;
-	m_response_size = rhs.m_response_size;
+	this->m_response_message = rhs.m_response_message;
+	this->m_response_size = rhs.m_response_size;
 
 	/* Config */
-	m_err_page_path = rhs.m_err_page_path;
+	this->m_err_page_path = rhs.m_err_page_path;
+	this->m_index_file = rhs.m_index_file;
+	this->m_root = rhs.m_root;
 
 	/* CGI */
-	m_cgi_client_addr = rhs.m_cgi_client_addr;
-	m_cgi_server_name = rhs.m_cgi_server_name;
-	m_cgi_port = rhs.m_cgi_port;
+	this->m_cgi_extension = rhs.m_cgi_extension;
+	this->m_cgi_client_addr = rhs.m_cgi_client_addr;
+	this->m_cgi_server_name = rhs.m_cgi_server_name;
+	this->m_cgi_port = rhs.m_cgi_port;
 	return (*this);
 }
 
@@ -151,6 +154,24 @@ Response::get_m_cgi_port() const
 	return (this->m_cgi_port);
 }
 
+std::vector<std::string>
+Response::get_m_index_file() const
+{
+	return (this->m_index_file);
+}
+
+std::string
+Response::get_m_root() const
+{
+	return (this->m_root);
+}
+
+std::vector<std::string>
+Response::get_m_cgi_extension() const
+{
+	return (this->m_cgi_extension);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -194,6 +215,27 @@ void
 Response::set_m_cgi_port(int cgi_port)
 {
 	this->m_cgi_port = cgi_port;
+	return ;
+}
+
+void
+Response::get_m_cgi_extension(std::vector<std::string> cgi_extension)
+{
+	this->m_cgi_extension = cgi_extension;
+	return ;
+}
+
+void
+Response::get_m_index_file(std::vector<std::string> index_file)
+{
+	this->m_index_file = index_file;
+	return ;
+}
+
+void
+Response::get_m_root(std::string root)
+{
+	this->m_root = root;
 	return ;
 }
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -11,8 +11,9 @@
 Response::Response()
 :m_status_code(404), m_date(""), m_content_language("ko, en"), m_content_type("text/html; charset=UTF-8"),
 m_server("ftnix/1.0 (MacOS)"), m_status_description(""), m_headers(), m_html_document(""), m_body(""),
-m_head(""), m_content_length(0), m_response_message(""), m_response_size(0), m_err_page_path("errors/default_error.html"),
-m_cgi_client_addr(), m_cgi_server_name(""), m_cgi_port(0), m_index_file(), m_root(""), m_cgi_extension()
+m_head(""), m_content_length(0), m_response_message(""), m_response_size(0), m_index_file(),
+m_err_page_path("./www/errors/default_error.html"), m_root(""), m_cgi_extension(), m_cgi_server_name(""),
+m_cgi_client_addr(), m_cgi_port(0)
 {
 }
 
@@ -337,7 +338,7 @@ Response::setPublicFileDocument(std::string publicPath)
 	}
 	catch (const std::exception& e)
 	{
-		std::cerr << e.what() << '\n';
+		std::cerr << "Err: setPublicFileDocument " << e.what() << '\n';
 		body = "";
 	}
 	this->m_html_document = body;

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -219,21 +219,21 @@ Response::set_m_cgi_port(int cgi_port)
 }
 
 void
-Response::get_m_cgi_extension(std::vector<std::string> cgi_extension)
+Response::set_m_cgi_extension(std::vector<std::string> cgi_extension)
 {
 	this->m_cgi_extension = cgi_extension;
 	return ;
 }
 
 void
-Response::get_m_index_file(std::vector<std::string> index_file)
+Response::set_m_index_file(std::vector<std::string> index_file)
 {
 	this->m_index_file = index_file;
 	return ;
 }
 
 void
-Response::get_m_root(std::string root)
+Response::set_m_root(std::string root)
 {
 	this->m_root = root;
 	return ;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -97,6 +97,50 @@ Server::get_m_port()
 /*============================================================================*/
 
 void
+Server::noteCGILocation()
+{
+	Response response;
+	std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
+	std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
+	int j = 0;
+
+	while (i != location_block.end())
+	{
+		printf("location %d\n", j++);
+		printf("path:: %s\n", i->get_m_path().c_str());
+		printf("root:: %s\n", i->get_m_root().c_str());
+		printf("cgi::path %d\n", i->get_m_cgi_path() == "");
+		{
+			std::vector<Method> limit_except = i->get_m_limit_except();
+			std::vector<Method>::const_iterator limit = limit_except.begin();
+			while (limit != limit_except.end())
+			{
+				printf("%d", *limit);
+				// std::cout << ' ' << *limit << std::endl;
+				switch (*limit)
+				{
+					case HEAD:
+					case GET:
+					case POST:
+					case PUT:
+					case DELETE:
+					case OPTIONS:
+					case TRACE:
+					default:
+						break;
+				}
+				limit++;
+			}
+			printf("\n");
+			// std::vector<std::string> index = i->get_m_index();
+			// std::vector<std::string> get_m_cgi();
+		}
+		i++;
+	}
+	return ;
+}
+
+void
 Server::init(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size)
 {
 	this->m_requests = std::vector<Request>(MAX_SOCK_NUM);
@@ -884,64 +928,46 @@ Server::sendResponse(int clientfd)
 
 	/* config Method */
 	// response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);
-	{
-		Response response;
-		std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
-		std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
-		int j = 0;
+	// {
+	// 	Response response;
+	// 	std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
+	// 	std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
+	// 	int j = 0;
 
-		while (i != location_block.end())
-		{
-			printf("location %d\n", j++);
-			printf("path:: %s\n", i->get_m_path().c_str());
-			printf("root:: %s\n", i->get_m_root().c_str());
-			printf("cgi::path %d\n", i->get_m_cgi_path() == "");
-			{
-				std::vector<Method> limit_except = i->get_m_limit_except();
-				std::vector<Method>::const_iterator limit = limit_except.begin();
-				while (limit != limit_except.end())
-				{
-					printf("%d", *limit);
-					// std::cout << ' ' << *limit << std::endl;
-					switch (*limit)
-					{
-						case HEAD:
-						case GET:
-							if (i->get_m_cgi_path() == "")
-								response = get(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						case POST:
-							if (i->get_m_cgi_path() == "")
-								response = post(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						case PUT:
-							if (i->get_m_cgi_path() == "")
-								response = put(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						case DELETE:
-							if (i->get_m_cgi_path() == "")
-								response = del(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						case OPTIONS:
-							if (i->get_m_cgi_path() == "")
-								response = options(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						case TRACE:
-							if (i->get_m_cgi_path() == "")
-								response = trace(i->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-							break;
-						default:
-							break;
-					}
-					limit++;
-				}
-				printf("\n");
-				// std::vector<std::string> index = i->get_m_index();
-				// std::vector<std::string> get_m_cgi();
-			}
-			i++;
-		}
-	}
+	// 	while (i != location_block.end())
+	// 	{
+	// 		printf("location %d\n", j++);
+	// 		printf("path:: %s\n", i->get_m_path().c_str());
+	// 		printf("root:: %s\n", i->get_m_root().c_str());
+	// 		printf("cgi::path %d\n", i->get_m_cgi_path() == "");
+	// 		{
+	// 			std::vector<Method> limit_except = i->get_m_limit_except();
+	// 			std::vector<Method>::const_iterator limit = limit_except.begin();
+	// 			while (limit != limit_except.end())
+	// 			{
+	// 				printf("%d", *limit);
+	// 				// std::cout << ' ' << *limit << std::endl;
+	// 				switch (*limit)
+	// 				{
+	// 					case HEAD:
+	// 					case GET:
+	// 					case POST:
+	// 					case PUT:
+	// 					case DELETE:
+	// 					case OPTIONS:
+	// 					case TRACE:
+	// 					default:
+	// 						break;
+	// 				}
+	// 				limit++;
+	// 			}
+	// 			printf("\n");
+	// 			// std::vector<std::string> index = i->get_m_index();
+	// 			// std::vector<std::string> get_m_cgi();
+	// 		}
+	// 		i++;
+	// 	}
+	// }
 
 	/* 전체 Response Message 확인 할 수 있음 */
 	// printf("%s\n", response.get_m_reponse_message().c_str());

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -111,22 +111,22 @@ Server::noteCGILocation()
 			switch (*limit)
 			{
 				case GET:
-					this->m_getLocation.push_back(*location_iter);
+					this->m_getLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				case POST:
-					this->m_postLocation.push_back(*location_iter);
+					this->m_postLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				case PUT:
-					this->m_putLocation.push_back(*location_iter);
+					this->m_putLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				case DELETE:
-					this->m_deleteLocation.push_back(*location_iter);
+					this->m_deleteLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				case OPTIONS:
-					this->m_optionsLocation.push_back(*location_iter);
+					this->m_optionsLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				case TRACE:
-					this->m_traceLocation.push_back(*location_iter);
+					this->m_traceLocation.push_back(HttpConfigLocation(*location_iter));
 					break;
 				default:
 					std::cout << "Error: noteCGILocation method switch error " << std::endl;
@@ -137,14 +137,14 @@ Server::noteCGILocation()
 		location_iter++;
 	}
 
-	// printf("\n");
-	// std::cout << "get: " << this->m_getLocation.size() << std::endl;
-	// std::cout << "post: " << this->m_postLocation.size() << std::endl;
-	// std::cout << "put: " << this->m_putLocation.size() << std::endl;
-	// std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
-	// std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
-	// std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
-	// printf("\n");
+	printf("\n");
+	std::cout << "get: " << this->m_getLocation.size() << std::endl;
+	std::cout << "post: " << this->m_postLocation.size() << std::endl;
+	std::cout << "put: " << this->m_putLocation.size() << std::endl;
+	std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
+	std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
+	std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
+	printf("\n");
 	return ;
 }
 
@@ -599,16 +599,33 @@ Response
 Server::methodPOST(int clientfd)
 {
 	Response response;
+
+	/* Response Setting */
 	response.set_m_err_page_path(this->m_err_page_path);
 
-	/* CGI Setting */
+	/* CGI Response Setting */
 	response.set_m_cgi_client_addr(this->m_client_addr.sin_addr.s_addr);
 	response.set_m_cgi_port(this->get_m_port());
 	response.set_m_cgi_server_name(this->get_m_server_name());
 	response = Server::page404(response.get_m_err_page_path());
 
+	/* Route */
 	response = post("/auth", this->m_requests[clientfd], response, Server::postAuth);
 	response = post("/auth.cgi", this->m_requests[clientfd], response, Server::executeCgi);
+
+	/* Config File Route */
+	printf("::size %lu::", this->m_getLocation.size());
+	if (this->m_getLocation.size() == 0)
+		return (response);
+	// std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_getLocation.begin();
+	// while (location_iter != this->m_getLocation.end())
+	// {
+	// 	/* CGI */
+	// 	if (location_iter.get_m_cgi_path() != "")
+
+	// 	location_iter++;
+	// }
+
 	return (response);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -99,65 +99,52 @@ Server::get_m_port()
 void
 Server::noteCGILocation()
 {
-	Response response;
 	std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
-	std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
-	int j = 0;
+	std::vector<HttpConfigLocation>::const_iterator location_iter = location_block.begin();
 
-	while (i != location_block.end())
+	while (location_iter != location_block.end())
 	{
-		printf("location %d\n", j++);
-		printf("path:: %s\n", i->get_m_path().c_str());
-		printf("root:: %s\n", i->get_m_root().c_str());
-		printf("cgi::path %d\n", i->get_m_cgi_path() == "");
+		std::vector<Method> limit_except = location_iter->get_m_limit_except();
+		std::vector<Method>::const_iterator limit = limit_except.begin();
+		while (limit != limit_except.end())
 		{
-			std::vector<Method> limit_except = i->get_m_limit_except();
-			std::vector<Method>::const_iterator limit = limit_except.begin();
-			while (limit != limit_except.end())
+			switch (*limit)
 			{
-				printf("%d", *limit);
-				// std::cout << ' ' << *limit << std::endl;
-				switch (*limit)
-				{
-					case GET:
-						this->m_getLocation.push_back(*i);
-						break;
-					case POST:
-						this->m_postLocation.push_back(*i);
-						break;
-					case PUT:
-						this->m_putLocation.push_back(*i);
-						break;
-					case DELETE:
-						this->m_deleteLocation.push_back(*i);
-						break;
-					case OPTIONS:
-						this->m_optionsLocation.push_back(*i);
-						break;
-					case TRACE:
-						this->m_traceLocation.push_back(*i);
-						break;
-					default:
-						std::cout << "Error: noteCGILocation method switch error " << std::endl;
-						break;
-				}
-				limit++;
+				case GET:
+					this->m_getLocation.push_back(*location_iter);
+					break;
+				case POST:
+					this->m_postLocation.push_back(*location_iter);
+					break;
+				case PUT:
+					this->m_putLocation.push_back(*location_iter);
+					break;
+				case DELETE:
+					this->m_deleteLocation.push_back(*location_iter);
+					break;
+				case OPTIONS:
+					this->m_optionsLocation.push_back(*location_iter);
+					break;
+				case TRACE:
+					this->m_traceLocation.push_back(*location_iter);
+					break;
+				default:
+					std::cout << "Error: noteCGILocation method switch error " << std::endl;
+					break;
 			}
-			printf("\n");
-			// std::vector<std::string> index = i->get_m_index();
-			// std::vector<std::string> get_m_cgi();
+			limit++;
 		}
-		i++;
+		location_iter++;
 	}
 
-	printf("\n");
-	std::cout << "get: " << this->m_getLocation.size() << std::endl;
-	std::cout << "post: " << this->m_postLocation.size() << std::endl;
-	std::cout << "put: " << this->m_putLocation.size() << std::endl;
-	std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
-	std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
-	std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
-	printf("\n");
+	// printf("\n");
+	// std::cout << "get: " << this->m_getLocation.size() << std::endl;
+	// std::cout << "post: " << this->m_postLocation.size() << std::endl;
+	// std::cout << "put: " << this->m_putLocation.size() << std::endl;
+	// std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
+	// std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
+	// std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
+	// printf("\n");
 	return ;
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -620,8 +620,6 @@ Server::methodPOST(int clientfd)
 	response = post("/auth.cgi", this->m_requests[clientfd], response, Server::executeCgi);
 
 	/* Config File Route */
-	std::cout << "postLocation: " << this->get_m_postLocation().size() << std::endl;
-	// printf("::size %lu::", this->m_postLocation.size());
 	if (this->m_postLocation.size() == 0)
 		return (response);
 	std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_postLocation.begin();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -624,14 +624,16 @@ Server::methodPOST(int clientfd)
 	// printf("::size %lu::", this->m_postLocation.size());
 	if (this->m_postLocation.size() == 0)
 		return (response);
-	// std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_getLocation.begin();
-	// while (location_iter != this->m_getLocation.end())
-	// {
-	// 	/* CGI */
-	// 	if (location_iter.get_m_cgi_path() != "")
+	std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_postLocation.begin();
+	while (location_iter != this->m_postLocation.end())
+	{
+		/* CGI */
+		if (location_iter->get_m_cgi_path() != "")
+			response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
+		// else
 
-	// 	location_iter++;
-	// }
+		location_iter++;
+	}
 
 	return (response);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -803,10 +803,10 @@ Server::getDirectory()
 }
 
 Response
-Server::get(std::string path, Request req, Response res, Response (*func)())
+Server::get(std::string path, Request req, Response res, Response (*func)(Request req, Response res))
 {
 	if (path == req.get_m_uri().get_m_path())
-		return (func());
+		return (func(req, res));
 	return (res);
 }
 
@@ -819,34 +819,34 @@ Server::post(std::string path, Request req, Response res, Response (*func)(Reque
 }
 
 Response
-Server::put(std::string path, Request req, Response res, Response (*func)())
+Server::put(std::string path, Request req, Response res, Response (*func)(Request req, Response res))
 {
 	if (path == req.get_m_uri().get_m_path())
-		return (func());
+		return (func(req, res));
 	return (res);
 }
 
 Response
-Server::del(std::string path, Request req, Response res, Response (*func)())
+Server::del(std::string path, Request req, Response res, Response (*func)(Request req, Response res))
 {
 	if (path == req.get_m_uri().get_m_path())
-		return (func());
+		return (func(req, res));
 	return (res);
 }
 
 Response
-Server::options(std::string path, Request req, Response res, Response (*func)())
+Server::options(std::string path, Request req, Response res, Response (*func)(Request req, Response res))
 {
 	if (path == req.get_m_uri().get_m_path())
-		return (func());
+		return (func(req, res));
 	return (res);
 }
 
 Response
-Server::trace(std::string path, Request req, Response res, Response (*func)())
+Server::trace(std::string path, Request req, Response res, Response (*func)(Request req, Response res))
 {
 	if (path == req.get_m_uri().get_m_path())
-		return (func());
+		return (func(req, res));
 	return (res);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -142,15 +142,6 @@ Server::noteHttpConfigLocation()
 		}
 		location_iter++;
 	}
-
-	printf("\n");
-	std::cout << "get: " << this->m_getLocation.size() << std::endl;
-	std::cout << "post: " << this->m_postLocation.size() << std::endl;
-	std::cout << "put: " << this->m_putLocation.size() << std::endl;
-	std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
-	std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
-	std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
-	printf("\n");
 	return ;
 }
 
@@ -602,6 +593,33 @@ Server::postAuth(Request req, Response res)
 }
 
 Response
+Server::HttpConfigPost(Request req, Response res)
+{
+	/* Request에 대한 요청 처리*/
+
+
+	/* Response */
+	Response response = Response();
+
+	return (
+		response
+			.setStatusCode(200)
+			.setCurrentDate()
+			.setContentLanguage("ko, en")
+			.setContentType("text/html; charset=UTF-8")
+			.setServer("ftnix/1.0 (MacOS)")
+			.setPublicFileDocument("srcs/login.html")
+			.setHttpResponseHeader("date", response.get_m_date())
+			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
+			.setHttpResponseHeader("content-language", response.get_m_content_language())
+			.setHttpResponseHeader("content-type", response.get_m_content_type())
+			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
+			.setHttpResponseHeader("server", response.get_m_server())
+			.makeHttpResponseMessage()
+	);
+}
+
+Response
 Server::methodPOST(int clientfd)
 {
 	Response response;
@@ -625,11 +643,16 @@ Server::methodPOST(int clientfd)
 	std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_postLocation.begin();
 	while (location_iter != this->m_postLocation.end())
 	{
+		/* HttpConfig path Response Setting */
+		response.set_m_cgi_extension(location_iter->get_m_cgi());
+		response.set_m_index_file(location_iter->get_m_index());
+		response.set_m_root(location_iter->get_m_root());
+
 		/* CGI */
 		if (location_iter->get_m_cgi_path() != "")
 			response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
-		// else
-
+		else
+			response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::HttpConfigPost);
 		location_iter++;
 	}
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -17,24 +17,38 @@ Server::Server(Server const &other)
 
 Server& Server::operator=(Server const &rhs)
 {
-	m_server_block = rhs.m_server_block;
-	m_server_name = rhs.m_server_name;
-	m_port = rhs.m_port;
-	m_err_page_path = rhs.m_err_page_path;
-	m_content_length = rhs.m_content_length;
-	m_location_size = rhs.m_location_size;
-	m_server_addr = rhs.m_server_addr;
-	m_client_addr = rhs.m_client_addr;
-	m_server_socket = rhs.m_server_socket;
-	m_client_socket = rhs.m_client_socket;
-	fd_num = rhs.fd_num;
-	sockfd = rhs.sockfd;
-	readn = rhs.readn;
-	maxfd = rhs.maxfd;
-	m_main_fds = rhs.m_main_fds;
-	m_copy_fds = rhs.m_copy_fds;
-	m_requests = rhs.m_requests;
-	m_responses = rhs.m_responses;
+	/* Config */
+	this->m_server_block = rhs.m_server_block;
+	this->m_server_name = rhs.m_server_name;
+	this->m_port = rhs.m_port;
+	this->m_err_page_path = rhs.m_err_page_path;
+	this->m_content_length = rhs.m_content_length;
+	this->m_location_size = rhs.m_location_size;
+	this->m_root = rhs.m_root;
+
+	/* Parse */
+	this->m_getLocation = rhs.m_getLocation;
+	this->m_postLocation = rhs.m_postLocation;
+	this->m_putLocation = rhs.m_putLocation;
+	this->m_deleteLocation = rhs.m_deleteLocation;
+	this->m_optionsLocation = rhs.m_optionsLocation;
+	this->m_traceLocation = rhs.m_traceLocation;
+
+	/* Socket */
+	this->m_server_addr = rhs.m_server_addr;
+	this->m_client_addr = rhs.m_client_addr;
+	this->m_server_socket = rhs.m_server_socket;
+	this->m_client_socket = rhs.m_client_socket;
+	this->fd_num = rhs.fd_num;
+	this->sockfd = rhs.sockfd;
+	this->readn = rhs.readn;
+	this->maxfd = rhs.maxfd;
+	this->m_main_fds = rhs.m_main_fds;
+	this->m_copy_fds = rhs.m_copy_fds;
+
+	/* Request, Response */
+	this->m_requests = rhs.m_requests;
+	this->m_responses = rhs.m_responses;
 	return (*this);
 };
 
@@ -146,7 +160,7 @@ Server::noteHttpConfigLocation()
 }
 
 void
-Server::init(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size)
+Server::init(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size, std::string root)
 {
 	this->m_requests = std::vector<Request>(MAX_SOCK_NUM);
 	this->m_responses = std::vector<Response>(MAX_SOCK_NUM);
@@ -159,6 +173,7 @@ Server::init(HttpConfigServer server_block, std::string server_name, int port, s
 		this->m_err_page_path = "./www/errors/default_error.html";
 	this->m_content_length = content_length;
 	this->m_location_size = location_size;
+	this->m_root = root;
 	return ;
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -891,7 +891,35 @@ Server::sendResponse(int clientfd)
 		response = methodNotAllow_405();
 
 	/* config Method */
-	response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);
+	// response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);
+	{
+		std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
+		std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
+		int j = 0;
+
+		while (i != location_block.end())
+		{
+			printf("location %d\n", j++);
+			printf("path:: %s\n", i->get_m_path().c_str());
+			printf("root:: %s\n", i->get_m_root().c_str());
+			printf("cgi::path %s\n", i->get_m_cgi_path().c_str());
+			{
+				std::vector<Method> limit_except = i->get_m_limit_except();
+				std::vector<Method>::const_iterator limit = limit_except.begin();
+				printf("method:: ");
+				while (limit != limit_except.end())
+				{
+					printf("%d", *limit);
+					// std::cout << ' ' << *limit << std::endl;
+					limit++;
+				}
+				printf("\n");
+				// std::vector<std::string> index = i->get_m_index();
+				// std::vector<std::string> get_m_cgi();
+			}
+			i++;
+		}
+	}
 
 	/* 전체 Response Message 확인 할 수 있음 */
 	// printf("%s\n", response.get_m_reponse_message().c_str());

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -902,10 +902,11 @@ Server::parseErrorResponse(int clientfd)
 }
 
 Response
-Server::getDirectory()
+Server::getDirectory(Request req, Response res)
 {
 	Response response = Response();
-
+	(void) req;
+	(void) res;
 	return (
 		response
 			.setStatusCode(200)
@@ -1007,47 +1008,7 @@ Server::sendResponse(int clientfd)
 		response = methodNotAllow_405();
 
 	/* config Method */
-	// response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);
-	// {
-	// 	Response response;
-	// 	std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
-	// 	std::vector<HttpConfigLocation>::const_iterator i = location_block.begin();
-	// 	int j = 0;
-
-	// 	while (i != location_block.end())
-	// 	{
-	// 		printf("location %d\n", j++);
-	// 		printf("path:: %s\n", i->get_m_path().c_str());
-	// 		printf("root:: %s\n", i->get_m_root().c_str());
-	// 		printf("cgi::path %d\n", i->get_m_cgi_path() == "");
-	// 		{
-	// 			std::vector<Method> limit_except = i->get_m_limit_except();
-	// 			std::vector<Method>::const_iterator limit = limit_except.begin();
-	// 			while (limit != limit_except.end())
-	// 			{
-	// 				printf("%d", *limit);
-	// 				// std::cout << ' ' << *limit << std::endl;
-	// 				switch (*limit)
-	// 				{
-	// 					case HEAD:
-	// 					case GET:
-	// 					case POST:
-	// 					case PUT:
-	// 					case DELETE:
-	// 					case OPTIONS:
-	// 					case TRACE:
-	// 					default:
-	// 						break;
-	// 				}
-	// 				limit++;
-	// 			}
-	// 			printf("\n");
-	// 			// std::vector<std::string> index = i->get_m_index();
-	// 			// std::vector<std::string> get_m_cgi();
-	// 		}
-	// 		i++;
-	// 	}
-	// }
+	response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);
 
 	/* 전체 Response Message 확인 할 수 있음 */
 	// printf("%s\n", response.get_m_reponse_message().c_str());

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -88,6 +88,12 @@ Server::get_m_port()
 	return (this->m_port);
 }
 
+std::vector<HttpConfigLocation>
+Server::get_m_postLocation()
+{
+	return (this->m_postLocation);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -97,7 +103,7 @@ Server::get_m_port()
 /*============================================================================*/
 
 void
-Server::noteCGILocation()
+Server::noteHttpConfigLocation()
 {
 	std::vector<HttpConfigLocation> location_block = this->m_server_block.get_m_location_block();
 	std::vector<HttpConfigLocation>::const_iterator location_iter = location_block.begin();
@@ -614,8 +620,9 @@ Server::methodPOST(int clientfd)
 	response = post("/auth.cgi", this->m_requests[clientfd], response, Server::executeCgi);
 
 	/* Config File Route */
-	printf("::size %lu::", this->m_getLocation.size());
-	if (this->m_getLocation.size() == 0)
+	std::cout << "postLocation: " << this->get_m_postLocation().size() << std::endl;
+	// printf("::size %lu::", this->m_postLocation.size());
+	if (this->m_postLocation.size() == 0)
 		return (response);
 	// std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_getLocation.begin();
 	// while (location_iter != this->m_getLocation.end())

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -154,9 +154,9 @@ Server::init(HttpConfigServer server_block, std::string server_name, int port, s
 	this->m_server_name = server_name;
 	this->m_port = port;
 	if (err_page_path != "")
-		this->m_err_page_path = err_page_path.substr(6, err_page_path.size()-6);
+		this->m_err_page_path = err_page_path;
 	else
-		this->m_err_page_path = "errors/default_error.html";
+		this->m_err_page_path = "./www/errors/default_error.html";
 	this->m_content_length = content_length;
 	this->m_location_size = location_size;
 	return ;
@@ -474,29 +474,6 @@ Server::parseQuery(std::string str)
 	return (m_query);
 }
 
-Response
-Server::postLoginSuccess()
-{
-	Response response = Response();
-
-	return (
-		response
-			.setStatusCode(200)
-			.setCurrentDate()
-			.setContentLanguage("ko, en")
-			.setContentType("text/html; charset=UTF-8")
-			.setServer("ftnix/1.0 (MacOS)")
-			.setPublicFileDocument("srcs/login.html")
-			.setHttpResponseHeader("date", response.get_m_date())
-			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
-			.setHttpResponseHeader("content-language", response.get_m_content_language())
-			.setHttpResponseHeader("content-type", response.get_m_content_type())
-			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
-			.setHttpResponseHeader("server", response.get_m_server())
-			.makeHttpResponseMessage()
-	);
-}
-
 std::map<std::string, std::string>
 Server::makeCgiEnvpMap(Request req, Response res)
 {
@@ -584,9 +561,9 @@ Server::postAuth(Request req, Response res)
 			printf("::%d:: ::%d::", username == "42seoul", password == "42seoul");
 
 			if (username == "42seoul" && password == "42seoul")
-				return (Server::postLoginSuccess());
+				return (Server::makeResponseMessage(200, "./www/srcs/login.html"));
 			else
-				return (Server::page200());
+				return (Server::makeResponseMessage(200, "./www/index.html"));
 		}
 	}
 	return (res);
@@ -596,26 +573,12 @@ Response
 Server::HttpConfigPost(Request req, Response res)
 {
 	/* Request에 대한 요청 처리*/
-
+	(void) req;
+	(void) res;
 
 	/* Response */
-	Response response = Response();
-
 	return (
-		response
-			.setStatusCode(200)
-			.setCurrentDate()
-			.setContentLanguage("ko, en")
-			.setContentType("text/html; charset=UTF-8")
-			.setServer("ftnix/1.0 (MacOS)")
-			.setPublicFileDocument("srcs/login.html")
-			.setHttpResponseHeader("date", response.get_m_date())
-			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
-			.setHttpResponseHeader("content-language", response.get_m_content_language())
-			.setHttpResponseHeader("content-type", response.get_m_content_type())
-			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
-			.setHttpResponseHeader("server", response.get_m_server())
-			.makeHttpResponseMessage()
+		Server::makeResponseMessage(200)
 	);
 }
 
@@ -811,6 +774,33 @@ Server::methodTRACE(int clientfd)
 /*============================================================================*/
 /*******************************  STATUS CODE *********************************/
 /*============================================================================*/
+
+Response
+Server::makeResponseMessage(
+	int statusCode, std::string path, std::string contentType,
+	int dateHour, int dateMinute, int dateSecond,
+	std::string contentLanguage, std::string server
+)
+{
+	Response response = Response();
+
+	return (
+		response
+			.setStatusCode(statusCode)
+			.setCurrentDate(dateHour, dateMinute, dateSecond)
+			.setPublicFileDocument(path)
+			.setContentLanguage(contentLanguage)
+			.setContentType(contentType)
+			.setServer(server)
+			.setHttpResponseHeader("date", response.get_m_date())
+			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
+			.setHttpResponseHeader("content-language", response.get_m_content_language())
+			.setHttpResponseHeader("content-type", response.get_m_content_type())
+			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
+			.setHttpResponseHeader("server", response.get_m_server())
+			.makeHttpResponseMessage()
+	);
+}
 
 /*============================================================================*/
 /**********************************  1XX  *************************************/

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -119,14 +119,26 @@ Server::noteCGILocation()
 				// std::cout << ' ' << *limit << std::endl;
 				switch (*limit)
 				{
-					case HEAD:
 					case GET:
+						this->m_getLocation.push_back(*i);
+						break;
 					case POST:
+						this->m_postLocation.push_back(*i);
+						break;
 					case PUT:
+						this->m_putLocation.push_back(*i);
+						break;
 					case DELETE:
+						this->m_deleteLocation.push_back(*i);
+						break;
 					case OPTIONS:
+						this->m_optionsLocation.push_back(*i);
+						break;
 					case TRACE:
+						this->m_traceLocation.push_back(*i);
+						break;
 					default:
+						std::cout << "Error: noteCGILocation method switch error " << std::endl;
 						break;
 				}
 				limit++;
@@ -137,6 +149,15 @@ Server::noteCGILocation()
 		}
 		i++;
 	}
+
+	printf("\n");
+	std::cout << "get: " << this->m_getLocation.size() << std::endl;
+	std::cout << "post: " << this->m_postLocation.size() << std::endl;
+	std::cout << "put: " << this->m_putLocation.size() << std::endl;
+	std::cout << "delete: " << this->m_deleteLocation.size() << std::endl;
+	std::cout << "options: " << this->m_optionsLocation.size() << std::endl;
+	std::cout << "trace: " << this->m_traceLocation.size() << std::endl;
+	printf("\n");
 	return ;
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -117,22 +117,22 @@ Server::noteHttpConfigLocation()
 			switch (*limit)
 			{
 				case GET:
-					this->m_getLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_getLocation.push_back(*location_iter);
 					break;
 				case POST:
-					this->m_postLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_postLocation.push_back(*location_iter);
 					break;
 				case PUT:
-					this->m_putLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_putLocation.push_back(*location_iter);
 					break;
 				case DELETE:
-					this->m_deleteLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_deleteLocation.push_back(*location_iter);
 					break;
 				case OPTIONS:
-					this->m_optionsLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_optionsLocation.push_back(*location_iter);
 					break;
 				case TRACE:
-					this->m_traceLocation.push_back(HttpConfigLocation(*location_iter));
+					this->m_traceLocation.push_back(*location_iter);
 					break;
 				default:
 					std::cout << "Error: noteCGILocation method switch error " << std::endl;

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -78,10 +78,10 @@ ServerManager::parseHttpConfig()
 }
 
 Server
-ServerManager::generateServer(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size)
+ServerManager::generateServer(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size, std::string root)
 {
 	Server server;
-	server.init(server_block, server_name, port, err_page_path, content_length,location_size);
+	server.init(server_block, server_name, port, err_page_path, content_length,location_size, root);
 	server.setServerAddr(port);
 	server.setServerSocket();
 	server.noteHttpConfigLocation();
@@ -99,7 +99,8 @@ ServerManager::initServers()
 				this->m_server_block[i].get_m_listen(),
 				this->m_server_block[i].get_m_default_error_page(),
 				this->m_server_block[i].get_m_content_length(),
-				this->m_server_block[i].get_m_location_block().size()
+				this->m_server_block[i].get_m_location_block().size(),
+				this->m_root
 			))
 		);
 	}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -16,16 +16,16 @@ ServerManager::ServerManager(ServerManager const &other)
 };
 ServerManager& ServerManager::operator=(ServerManager const &rhs)
 {
-	m_httpConfig = rhs.m_httpConfig;
+	this->m_httpConfig = rhs.m_httpConfig;
 
-	m_server_block = rhs.m_server_block;
-	m_server = rhs.m_server;
-	m_server_size = rhs.m_server_size;
+	this->m_server_block = rhs.m_server_block;
+	this->m_server = rhs.m_server;
+	this->m_server_size = rhs.m_server_size;
 
-	m_software_name = rhs.m_software_name;
-	m_software_version = rhs.m_software_version;
-	m_mime_include = rhs.m_mime_include;
-	m_root = rhs.m_root;
+	this->m_software_name = rhs.m_software_name;
+	this->m_software_version = rhs.m_software_version;
+	this->m_mime_include = rhs.m_mime_include;
+	this->m_root = rhs.m_root;
 	return (*this);
 };
 
@@ -85,23 +85,23 @@ ServerManager::generateServer(HttpConfigServer server_block, std::string server_
 	server.init(server_block, server_name, port, err_page_path, content_length,location_size);
 	server.setServerAddr(port);
 	server.setServerSocket();
-	server.noteCGILocation();
+	server.noteHttpConfigLocation();
 	return (server);
 }
 
 void
 ServerManager::initServers()
 {
-	for (size_t i = 0; i < m_server_size; i++) {
+	for (size_t i = 0; i < this->m_server_size; i++) {
 		this->m_server.push_back(
-			generateServer(
+			new Server(generateServer(
 				this->m_server_block[i],
 				this->m_server_block[i].get_m_server_name(),
 				this->m_server_block[i].get_m_listen(),
 				this->m_server_block[i].get_m_default_error_page(),
 				this->m_server_block[i].get_m_content_length(),
 				this->m_server_block[i].get_m_location_block().size()
-			)
+			))
 		);
 	}
 	return ;
@@ -111,7 +111,7 @@ void
 ServerManager::runServers()
 {
 	for (size_t i = 0; i < m_server_size; i++) {
-		this->m_server[i].runServer();
+		this->m_server[i]->runServer();
 	}
 	return ;
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -70,7 +70,6 @@ ServerManager::storeParseValue()
 void
 ServerManager::parseHttpConfig()
 {
-	this->m_httpConfig.setConfigFileCheckValid("ftinx_sample.conf");
 	this->m_httpConfig.parseConfigFile("ftinx_sample.conf");
 	this->m_httpConfig.printConfigFileInfo();
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -85,6 +85,7 @@ ServerManager::generateServer(HttpConfigServer server_block, std::string server_
 	server.init(server_block, server_name, port, err_page_path, content_length,location_size);
 	server.setServerAddr(port);
 	server.setServerSocket();
+	server.noteCGILocation();
 	return (server);
 }
 

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -370,7 +370,7 @@ publicFileToString(std::string file_path)
 	char buffer[BUFFER_SIZE];
 	std::string ret;
 
-	if ((fd = open(("./www/" + file_path).c_str(), O_RDONLY)) < 0)
+	if ((fd = open((file_path).c_str(), O_RDONLY)) < 0)
 		throw std::exception();
 	ft::memset(buffer, 0, BUFFER_SIZE);
 	while ((bytes = read(fd, buffer, BUFFER_SIZE) > 0))


### PR DESCRIPTION
## 패치 내용

- server에 아래 vector들이 추가됐습니다. (이제 모든 severblock에 모든 요소를 순회안해도 원하는 Method에 접근할 수 있습니다.
```c++
		/* Parse */
		std::vector<HttpConfigLocation> m_getLocation;
		std::vector<HttpConfigLocation> m_postLocation;
		std::vector<HttpConfigLocation> m_putLocation;
		std::vector<HttpConfigLocation> m_deleteLocation;
		std::vector<HttpConfigLocation> m_optionsLocation;
		std::vector<HttpConfigLocation> m_traceLocation;
```
- 사용법
```c++
Response
Server::methodPOST(int clientfd)
{
	Response response;

	/* Response Setting */
	response.set_m_err_page_path(this->m_err_page_path);

	/* CGI Response Setting */
	response.set_m_cgi_client_addr(this->m_client_addr.sin_addr.s_addr);
	response.set_m_cgi_port(this->get_m_port());
	response.set_m_cgi_server_name(this->get_m_server_name());
	response = Server::page404(response.get_m_err_page_path());

	/* Route */
	response = post("/auth", this->m_requests[clientfd], response, Server::postAuth);
	response = post("/auth.cgi", this->m_requests[clientfd], response, Server::executeCgi);

	/* Config File Route */
	if (this->m_postLocation.size() == 0)
		return (response);
	std::vector<HttpConfigLocation>::const_iterator location_iter = this->m_postLocation.begin();
	while (location_iter != this->m_postLocation.end())
	{
		/* HttpConfig path Response Setting */
		response.set_m_cgi_extension(location_iter->get_m_cgi());
		response.set_m_index_file(location_iter->get_m_index());
		response.set_m_root(location_iter->get_m_root());

		/* CGI */
		if (location_iter->get_m_cgi_path() != "")
			response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::executeCgi);
		else
			response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::HttpConfigPost);
		location_iter++;
	}

	return (response);
}
```
- ftinx_sample.conf 파일의 전체 root path가 서버에 추가됐습니다. (Server class의 m_root입니다.)
```
http {
    software_name ftinx #프로그램명
    software_version 0.1 #버전
    include mime.types
    root /Users/ftinx/Webserv/
```

<img src="https://user-images.githubusercontent.com/22424891/111862043-0102ea00-8996-11eb-8873-517aacf9d811.png" height="300px"/>

- makeResponseMessage가 추가됐습니다. (일괄적으로 Response 메세지 생성가능)
```c++
		static Response makeResponseMessage(
			int statusCode,
			std::string path = "./www/index.html", std::string contentType="text/html; charset=UTF-8",
			int dateHour=0, int dateMinute=0, int dateSecond=0,
			std::string contentLanguage="ko, en", std::string server="ftnix/1.0 (MacOS)"
		);
```
- 사용법
```c++
Response
Server::HttpConfigPost(Request req, Response res)
{
	/* Request에 대한 요청 처리*/
	(void) req;
	(void) res;

	/* Response */
	return (
		Server::makeResponseMessage(200)
	);
}
```
- httpconfig location의 path를 response에서 사용할 수 있습니다.
```c++
		response.set_m_cgi_extension(location_iter->get_m_cgi());
		response.set_m_index_file(location_iter->get_m_index());
		response.set_m_root(location_iter->get_m_root());
```
- filetoDocument함수의 경로가 './www/' default에서 매개변수 path입력값으로 변경됐습니다.
- [Response] setPublicFileDocument 문제 #137 해결
- 개인 config 파일 추가