### PR TITLE
[FEAT] add parseMimeTypes, fix fileToString

### DIFF
--- a/includes/HttpConfig.hpp
+++ b/includes/HttpConfig.hpp
@@ -24,9 +24,9 @@ class HttpConfig
 		std::string m_include;
 		std::string m_root;
 		std::vector<HttpConfigServer> m_server_block;
+		std::map<std::string, std::string> m_mime_types;
 
 	private:
-
 		/* utils */
 		bool checkStartHttp(); // m_liens의 시작이 "http" 인지 여부 확인
 		bool checkBlankLine(std::string str);
@@ -48,6 +48,7 @@ class HttpConfig
 		std::vector<HttpConfigServer> get_m_server_block() const;
 
 		/* setter */
+		void parseMimeTypes();
 		void setConfigFileCheckValid(std::string file_path);
 		// void setConfigFile();
 		// void setConfigLines();

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -14,7 +14,7 @@
 # include <fcntl.h>
 # include <unistd.h>
 
-# define BUFFER_SIZE 4096
+# define BUFFER_SIZE 20000// 4096
 
 enum Method
 {

--- a/mime.types
+++ b/mime.types
@@ -1,0 +1,93 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation    pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet            xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document      docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -10,7 +10,8 @@ HttpConfig::HttpConfig()
 	m_version(""),
 	m_include(""),
 	m_root(""),
-	m_server_block()
+	m_server_block(),
+	m_mime_types()
 {
 }
 
@@ -27,6 +28,7 @@ HttpConfig::operator=(HttpConfig const &rhs)
 	m_include = rhs.m_include;
 	m_root = rhs.m_root;
 	m_server_block = rhs.m_server_block;
+	m_mime_types = rhs.m_mime_types;
 	return (*this);
 }
 
@@ -99,9 +101,9 @@ HttpConfig::checkStartHttp()
 bool
 HttpConfig::checkBlankLine(std::string str)
 {
-    if (str.empty() == false)
-        return (false);
-    return (true);
+	if (str.empty() == false)
+		return (false);
+	return (true);
 }
 
 bool
@@ -141,6 +143,30 @@ HttpConfig::checkCurlyBracketsDouble(std::string str)
 			return (true);
 	}
 	return (false);
+}
+
+void
+HttpConfig::parseMimeTypes()
+{
+	std::string file = ft::fileToString(std::string("./") + this->m_include);
+	std::vector<std::string> lines = ft::split(file, '\n');
+
+	for (std::vector<std::string>::const_iterator it = lines.begin() ; it != lines.end() ; ++it)
+	{
+		if (checkBlankLine(*it) || it->find("{") != std::string::npos || it->find("}") != std::string::npos)
+			continue ;
+		std::vector<std::string> tmp = ft::split(ft::rtrim(ft::ltrim(*it, " "), ";"), " ");
+		std::string value = tmp.front();
+		tmp.erase(tmp.begin());
+		for (std::vector<std::string>::const_iterator i = tmp.begin() ; i != tmp.end() ; ++i)
+			this->m_mime_types.insert(make_pair(*i, value));
+	}
+	// 파싱 잘 되었는지 출력 테스트
+	// std::cout << "-----------mime_types_map----------" << std::endl;
+	// std::map<std::string, std::string>::const_iterator test;
+	// for (test = this->m_mime_types.begin() ; test != this->m_mime_types.end() ; ++test)
+	// 	std::cout << test->first << " " << test->second << std::endl;
+	// std::cout << "-----------------------------------" << std::endl;
 }
 
 void
@@ -191,7 +217,10 @@ HttpConfig::parseConfigFile(std::string file_path)
 		else if (line.front().compare("software_version") == 0)
 			this->m_version = line.back();
 		else if (line.front().compare("include") == 0)
+		{
 			this->m_include = line.back();
+			parseMimeTypes();
+		}
 		else if (line.front().compare("root") == 0)
 		{
 			// HttpConfigLocation::checkDirExist(line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -344,6 +344,24 @@ isValidDirPath(std::string path)
 	return (false); // 폴더가 아님
 }
 
+// std::string
+// fileToString(std::string file_path)
+// {
+// 	int fd;
+// 	int bytes;
+// 	char buffer[BUFFER_SIZE];
+// 	std::string ret;
+
+// 	if ((fd = open(file_path.c_str(), O_RDONLY)) < 0)
+// 		throw std::exception();
+// 	ft::memset(buffer, 0, BUFFER_SIZE);
+// 	while ((bytes = read(fd, buffer, BUFFER_SIZE) > 0))
+// 		ret += std::string(buffer);
+// 	if (bytes < 0)
+// 		throw std::exception();
+// 	return (ret);
+// }
+
 std::string
 fileToString(std::string file_path)
 {
@@ -354,11 +372,13 @@ fileToString(std::string file_path)
 
 	if ((fd = open(file_path.c_str(), O_RDONLY)) < 0)
 		throw std::exception();
-	ft::memset(buffer, 0, BUFFER_SIZE);
-	while ((bytes = read(fd, buffer, BUFFER_SIZE) > 0))
+	ft::memset(reinterpret_cast<void *>(buffer), 0, BUFFER_SIZE);
+	while ((bytes = read(fd, reinterpret_cast<void *>(buffer), BUFFER_SIZE) > 0))
+	{
+		if (bytes < 0)
+			throw std::exception();
 		ret += std::string(buffer);
-	if (bytes < 0)
-		throw std::exception();
+	}
 	return (ret);
 }
 


### PR DESCRIPTION
- mime.types 파일 추가
https://github.com/nginx/nginx/blob/master/conf/mime.types

- HttpConfig에 mime type 파싱 추가
  ```c++
  std::map<std::string, std::string> m_mime_types; 확장자가 key, Content-type이 value
  void parseMimeTypes(); mime type file 파싱
  ```

- Utils의 FileToString 함수
  - 버퍼사이즈보다 큰 파일을 오픈하려 할 때 문제 생김 -> 버퍼사이즈를 키우는 방법으로 임시 수정

