### PR TITLE
[FIX] chunked message get error

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -52,7 +52,7 @@ class Request
 		std::string getMethod();
 		std::string getContentLength();
 		std::string getContentType();
-		bool isBreakCondition(std::string, bool*, int, int);
+		bool isBreakCondition(bool*, int, int);
 		bool getMessage(int);
 		bool parseMessage();
 		bool parseRequestLine(std::string);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -190,6 +190,8 @@ Request::isBreakCondition(bool *chunked, int body_bytes, int header_bytes)
 	size_t pos;
 	std::string tmp;
 
+	if ((pos = this->m_message.find("Transfer-Encoding: chunked")) != std::string::npos)
+		*chunked = true;
 	if (*chunked == true && (pos = this->m_message.find("0\r\n\r\n")) == this->m_message.size() - 5)
 	{
 		this->m_message = this->m_message.substr(0, pos + 5);
@@ -204,8 +206,6 @@ Request::isBreakCondition(bool *chunked, int body_bytes, int header_bytes)
 			content_length = std::stoi(tmp);
 		}
 	}
-	if ((pos = this->m_message.find("Transfer-Encoding: chunked")) != std::string::npos)
-		*chunked = true;
 	if (content_length >= 0 && content_length <= body_bytes)
 	{
 		this->m_message = this->m_message.substr(0, header_bytes + content_length);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -166,7 +166,7 @@ Request::getContentLength()
 {
 	std::map<std::string, std::string>::const_iterator it;
 
-	it = this->m_headers.find("content-length");
+	it = this->m_headers.find("Content-Length");
 	if (it == this->m_headers.end())
 		return ("");
 	return (it->second);
@@ -177,41 +177,46 @@ Request::getContentType()
 {
 	std::map<std::string, std::string>::const_iterator it;
 
-	it = this->m_headers.find("content-type");
+	it = this->m_headers.find("Content-Type");
 	if (it == this->m_headers.end())
 		return ("text/html");
 	return (it->second);
 }
 
 bool
-Request::isBreakCondition(std::string str, bool *chunked, int body_bytes, int header_bytes)
+Request::isBreakCondition(bool *chunked, int body_bytes, int header_bytes)
 {
 	static int content_length = -1;
 	size_t pos;
 	std::string tmp;
 
-	if (*chunked == true && str == "\r\n") //error의 소지가 있음
-		return (true);
-	if ((pos = this->m_message.find("content-length:")) != std::string::npos)
+	if (*chunked == true && (pos = this->m_message.find("0\r\n\r\n")) == this->m_message.size() - 5)
 	{
-		tmp = m_message.substr(pos + strlen("content-length:"), std::string::npos);
+		this->m_message = this->m_message.substr(0, pos + 5);
+		return (true);
+	}
+	if ((pos = this->m_message.find("Content-Length:")) != std::string::npos)
+	{
+		tmp = m_message.substr(pos + strlen("Content-Length:"), std::string::npos);
 		if ((pos = tmp.find_first_of("\n")) != std::string::npos)
 		{
 			tmp = ft::trim(tmp.substr(0, pos), " \r");
 			content_length = std::stoi(tmp);
 		}
 	}
+	if ((pos = this->m_message.find("Transfer-Encoding: chunked")) != std::string::npos)
+		*chunked = true;
 	if (content_length >= 0 && content_length <= body_bytes)
 	{
 		this->m_message = this->m_message.substr(0, header_bytes + content_length);
 		return (true);
 	}
-	else if ((pos = this->m_message.find("\r\n\r\n")) != std::string::npos)
+	else if ((pos = this->m_message.find("\r\n\r\n")) != std::string::npos && *chunked == false)
 	{
+		std::cout << m_message << std::endl;
 		this->m_message = this->m_message.substr(0, pos);
 		return (true);
 	}
-	//td::cout << "isBreakCondition False" << std::endl;
 	return (false);
 }
 
@@ -243,7 +248,7 @@ Request::getMessage(int fd)
 			else
 				body_bytes += ret;
 		}
-		if (isBreakCondition(str, &chunked, body_bytes, header_bytes))
+		if (isBreakCondition(&chunked, body_bytes, header_bytes))
 			break;
 		memset(recvline, 0, MAXLINE);
 	}


### PR DESCRIPTION
Transfer-Encoding: chunked 일 때 메세지가 제대로 들어오지 않는 문제가 있었습니다.

```
	if ((pos = this->m_message.find("Transfer-Encoding: chunked")) != std::string::npos)
		*chunked = true;
	if (*chunked == true && (pos = this->m_message.find("0\r\n\r\n")) == this->m_message.size() - 5)
	{
		this->m_message = this->m_message.substr(0, pos + 5);
		return (true);
	}
```
- 해당 헤더가 들어올 때 플래그를 켜주고
- `0\r\n\r\n`이 들어올 때까지 메세지를 받고, 해당 구문이 들어오면 그 부분까지 메세지를 자릅니다

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding