### PR TITLE
[FEAT] update Config -> default root path setting, update mime.types parse

### DIFF
--- a/includes/HttpConfigLocation.hpp
+++ b/includes/HttpConfigLocation.hpp
@@ -31,6 +31,7 @@ class HttpConfigLocation
 		bool get_m_autoindex() const;
 
 		/* setter */
+		void set_m_root(std::string root);
 
 		/* utils */
 		static bool checkCommentLine(std::string str);
@@ -45,7 +46,7 @@ class HttpConfigLocation
 		};
 
 		/* key func. */
-		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, size_t &idx);
+		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, std::string root, size_t &idx);
 };
 
 #endif

--- a/includes/HttpConfigServer.hpp
+++ b/includes/HttpConfigServer.hpp
@@ -28,6 +28,8 @@ class HttpConfigServer
 
 		/* setter */
 
+		void set_m_root(std::string m_root);
+
 		/* key func. */
 		HttpConfigServer& parseServerBlock(std::vector<std::string> lines, std::string root, size_t &idx);
 };

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -225,7 +225,8 @@ HttpConfig::parseConfigFile(std::string file_path)
 		else if (line.front().compare("include") == 0)
 		{
 			this->m_include = line.back();
-			parseMimeTypes();
+			if (ft::checkValidFileExtension(this->m_include, "types"))
+				parseMimeTypes();
 		}
 		else if (line.front().compare("root") == 0)
 		{

--- a/srcs/HttpConfigLocation.cpp
+++ b/srcs/HttpConfigLocation.cpp
@@ -89,6 +89,12 @@ HttpConfigLocation::get_m_autoindex() const
 /********************************  Setter  ************************************/
 /*============================================================================*/
 
+void
+HttpConfigLocation::set_m_root(std::string root)
+{
+	this->m_root = root;
+}
+
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/
@@ -133,7 +139,7 @@ const char* HttpConfigLocation::parseErrorException::what() const throw()
 }
 
 HttpConfigLocation&
-HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, size_t &idx)
+HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::string root, size_t &idx)
 {
 	while (42)
 	{
@@ -204,5 +210,7 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, size_t &i
 		}
 		idx++;
 	}
+	if (this->m_root.compare("") == 0)
+		this->m_root = root;
 	return (*this);
 }

--- a/srcs/HttpConfigServer.cpp
+++ b/srcs/HttpConfigServer.cpp
@@ -112,7 +112,7 @@ HttpConfigServer::parseServerBlock(std::vector<std::string> lines, std::string r
 		{
 			location_block_exist = true;
 			HttpConfigLocation location = HttpConfigLocation();
-			this->m_location_block.push_back(location.parseLocationBlock(lines, idx));
+			this->m_location_block.push_back(location.parseLocationBlock(lines, root, idx));
 			continue ;
 		}
 		else if (line.front().compare("}") == 0)

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -442,6 +442,21 @@ getMethodString(Method method)
 
 
 bool
+checkValidFileExtension(std::string file_name, std::string ext)
+{
+	std::vector<std::string> tmp;
+	std::string extension;
+
+	if (file_name.find(".") == std::string::npos)
+		return (false);
+	tmp = ft::split(file_name, '.');
+	extension = tmp.back();
+	if (ext.compare(extension) == 0)
+		return (true);
+	return (false);
+}
+
+bool
 checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list)
 {
 	std::vector<std::string> tmp;


### PR DESCRIPTION
- location block 에 root 가 없는 경우 http 의 root를 기본 값으로 갖도록 수정

- http block의 include에 요소가 들어왔을 때 확장자가 types인 경우만 parseMimeTypes 작동하도록 수정
  - utils에 단일 확장자 확인하는 함수 오버로딩 (checkValidFileExtension)