### PR TITLE
[FEAT] add resetRequest() #171

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include "Uri.hpp"
 #include "Utils.hpp"
+#include "HttpConfigLocation.hpp"
 
 #define MAXLINE 2048
 #define SOCK_SETSIZE 1021
@@ -25,6 +26,8 @@ class Request
 		std::map<std::string, std::string> m_headers;
 		std::string m_body;
 		int m_error_code;
+		std::string m_reset_path;
+		HttpConfigLocation m_location_block;
 
 	public:
 		Request();
@@ -42,6 +45,8 @@ class Request
 		std::map<std::string, std::string> get_m_headers() const;
 		std::string get_m_body() const;
 		int	get_m_error_code() const;
+		std::string get_m_reset_path() const;
+		HttpConfigLocation get_m_location_block() const;
 		void set_m_http_version(std::string);
 		void set_m_cgi_version(std::string);
 		void set_m_check_cgi(bool);
@@ -49,6 +54,9 @@ class Request
 		//setHeaders
 		void set_m_body(std::string);
 		void set_m_error_code(int);
+		void set_m_reset_path(std::string);
+		void set_m_location_block(HttpConfigLocation);
+
 		std::string getMethod();
 		std::string getContentLength();
 		std::string getContentType();

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -111,7 +111,7 @@ class Server
 		void getRequest();
 		std::vector<HttpConfigLocation> getMethodLocation(Method method);
 		bool checkAcceptedMethod(std::vector<Method> v, Method method);
-		bool isMatchingLocation(std::string location, std::string path_in, std::string *rest)
+		bool isMatchingLocation(std::string location, std::string path_in, std::string *rest);
 		std::string checkHttpConfigFilePath(std::string path_in);
 		void resetRequest(Request *req);
 		static Response makeResponseMessage(

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -111,6 +111,7 @@ class Server
 		void getRequest();
 		std::vector<HttpConfigLocation> getMethodLocation(Method method);
 		bool checkAcceptedMethod(std::vector<Method> v, Method method);
+		bool isMatchingLocation(std::string location, std::string path_in, std::string *rest)
 		std::string checkHttpConfigFilePath(std::string path_in);
 		void resetRequest(Request *req);
 		static Response makeResponseMessage(

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -111,6 +111,7 @@ class Server
 		void getRequest();
 		std::vector<HttpConfigLocation> getMethodLocation(Method method);
 		bool checkAcceptedMethod(std::vector<Method> v, Method method);
+		std::string checkHttpConfigFilePath(std::string path_in);
 		void resetRequest(Request *req);
 		static Response makeResponseMessage(
 			int statusCode,
@@ -127,8 +128,8 @@ class Server
 		);
 		void sendResponse(int clientfd);
 		Response parseErrorResponse(int clientfd);
-		bool checkHttpConfigFilePath(std::string path, std::string method="");
-		bool checkHttpConfigFilePathHead(std::string path);
+		// bool checkHttpConfigFilePath(std::string path, std::string method="");
+		// bool checkHttpConfigFilePathHead(std::string path);
 
 		/* SERVER METHOD UTIL */
 		static Response getDirectory(Request req, Response res);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -109,6 +109,9 @@ class Server
 		void closeServer();
 
 		void getRequest();
+		std::vector<HttpConfigLocation> getMethodLocation(Method method);
+		bool checkAcceptedMethod(std::vector<Method> v, Method method);
+		void resetRequest(Request *req);
 		static Response makeResponseMessage(
 			int statusCode,
 			std::string path = "./www/index.html", std::string method="", std::string contentType="text/html; charset=UTF-8",

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -103,6 +103,18 @@ Request::get_m_error_code() const
 	return (this->m_error_code);
 }
 
+std::string
+Request::get_m_reset_path() const
+{
+	return (this->m_reset_path);
+}
+
+HttpConfigLocation
+Request::get_m_location_block() const
+{
+	return (this->m_location_block);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -135,6 +147,18 @@ void
 Request::set_m_error_code(int error_code)
 {
 	this->m_error_code = error_code;
+}
+
+void
+Request::set_m_reset_path(std::string path)
+{
+	this->m_reset_path = path;
+}
+
+void
+Request::set_m_location_block(HttpConfigLocation block)
+{
+	this->m_location_block = block;
 }
 
 /*============================================================================*/

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -830,6 +830,8 @@ Server::methodPUT(int clientfd)
 	int status_code = 0;
 
 	/* cgi part should be added */
+	if(checkHttpConfigFilePath(path))
+		return (Server::makeResponseMessage(405, ""));
 	std::cout << this->m_root + path << std::endl;
 	if (ft::isValidFilePath(this->m_root + path) == false)
 	{
@@ -843,7 +845,6 @@ Server::methodPUT(int clientfd)
 			return (Server::page404(this->m_err_page_path));
 		status_code = 200;
 	}
-	/* 405 check */
 	body = req.get_m_body().c_str();
 	if (write(fd, req.get_m_body().c_str(), ft::strlen(req.get_m_body().c_str())) < 0)
 	{

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -428,6 +428,8 @@ Server::getRequest()
 			this->m_requests[this->sockfd] = Request();
 			this->m_requests[this->sockfd].getMessage(this->sockfd);
 			this->resetRequest(&this->m_requests[this->sockfd]);
+			std::cout << "[\033" << std::endl;
+			std::cout << this->m_requests[this->sockfd].get_m_reset_path << std::endl;
 
 			FD_SET(this->sockfd, &this->m_write_fds);
 			//FD_CLR(this->sockfd, &this->m_main_fds);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -428,8 +428,8 @@ Server::getRequest()
 			this->m_requests[this->sockfd] = Request();
 			this->m_requests[this->sockfd].getMessage(this->sockfd);
 			this->resetRequest(&this->m_requests[this->sockfd]);
-			std::cout << "[\033" << std::endl;
-			std::cout << this->m_requests[this->sockfd].get_m_reset_path << std::endl;
+			std::cout << "\033[32m****************\033[0m" << std::endl;
+			std::cout << this->m_requests[this->sockfd].get_m_reset_path() << std::endl;
 
 			FD_SET(this->sockfd, &this->m_write_fds);
 			//FD_CLR(this->sockfd, &this->m_main_fds);
@@ -467,16 +467,41 @@ Server::getMethodLocation(Method method)
 }
 
 bool
-Server::checkAcceptedMethod(std::vector<Method> v, Method method)
+isMatchingLocation(std::string location, std::string path_in, std::string *rest)
 {
-	std::vector<Method>::const_iterator it;
-
-	for(it = v.begin(); it != v.end(); ++it)
+	try
 	{
-		if (*it == method)
-			return (true);
+		if (path_in.compare(0, location.size(), location) != 0)
+			return (false);
+		*rest = path_in.substr(location.size(), std::string::npos);
+		if (location == "/")
+			*rest = "/" + *rest;
+		if ((*rest).size() && (*rest)[0] != '/')
+			return (false);
 	}
-	return (false);
+	catch(const std::exception& e)
+	{
+		return (false);
+	}
+	return (true);
+}
+
+std::string
+Server::checkHttpConfigFilePath(std::string path_in)
+{
+	std::vector<std::string>::const_iterator it;
+	std::string rest;
+	std::string ret("");
+
+	for(it = m_httpConfigFilePathSet.begin(); it != m_httpConfigFilePathSet.end(); it++)
+	{
+		if (isMatchingLocation(*it, path_in, &rest) == true)
+		{
+			if (ret.size() < (*it).size())
+				ret = *it;
+		}
+	}
+	return (ret);
 }
 
 void
@@ -486,10 +511,10 @@ Server::resetRequest(Request *req)
 	std::vector<HttpConfigLocation>::const_iterator it;
 	HttpConfigLocation block;
 	std::string path_in = req->get_m_uri().get_m_path();
+	std::string path_loc("");
 	std::string path_out("");
 	std::string tmp;
 	std::string rest;
-	bool method_accepted;
 
 	if (loc_block.empty())
 	{
@@ -499,31 +524,23 @@ Server::resetRequest(Request *req)
 	for (it = loc_block.begin(); it != loc_block.end(); ++it)
 	{
 		tmp = it->get_m_path();
-		try
+		if (isMatchingLocation(tmp, path_in, &rest) == false)
+			continue;
+		if (path_loc.size() < tmp.size())
 		{
-			if (path_in.compare(0, tmp.size(), tmp) != 0)
-				continue;
-			rest = path_in.substr(tmp.size(), std::string::npos);
-			if (rest.size() && rest[0] != '/')
-				continue;
-			if (path_out.size() < tmp.size())
-			{
-				path_out = tmp;
-				block = *it;
-				method_accepted = checkAcceptedMethod(it->get_m_limit_except(), req->get_m_method());
-			}
-		}
-		catch(const std::exception &e)
-		{
+			path_loc = tmp;
+			path_out = it->get_m_root() + rest;
+			block = *it;
+			std::cout << "PATH_LOC: " << path_loc << std::endl;
 		}
 	}
-	if (method_accepted == false)
-		req->set_m_error_code(405);
-	else
+	if (checkHttpConfigFilePath(path_in) != path_loc)
 	{
-		req->set_m_reset_path(path_out);
-		req->set_m_location_block(block);
+		req->set_m_error_code(405);
+		return;
 	}
+	req->set_m_reset_path(path_out);
+	req->set_m_location_block(block);
 }
 
 /*============================================================================*/
@@ -602,49 +619,49 @@ Server::makeAutoindexPage(std::string path)
 	return (page);
 }
 
-bool
-Server::checkHttpConfigFilePathHead(std::string path)
-{
-	int path_length = path.length();
-	std::vector<HttpConfigLocation>::const_iterator headlocation_iter = this->m_headLocation.begin();
-	while (headlocation_iter != this->m_headLocation.end())
-	{
-		int headlocation_length = headlocation_iter->get_m_path().length();
-		if (path == headlocation_iter->get_m_path())
-			return (true);
-		if (path_length > headlocation_length
-		&& headlocation_length > 1
-		&& path.substr(0, headlocation_length) == headlocation_iter->get_m_path())
-			return (true);
-		headlocation_iter++;
-	}
-	return (false);
-}
+// bool
+// Server::checkHttpConfigFilePathHead(std::string path)
+// {
+// 	int path_length = path.length();
+// 	std::vector<HttpConfigLocation>::const_iterator headlocation_iter = this->m_headLocation.begin();
+// 	while (headlocation_iter != this->m_headLocation.end())
+// 	{
+// 		int headlocation_length = headlocation_iter->get_m_path().length();
+// 		if (path == headlocation_iter->get_m_path())
+// 			return (true);
+// 		if (path_length > headlocation_length
+// 		&& headlocation_length > 1
+// 		&& path.substr(0, headlocation_length) == headlocation_iter->get_m_path())
+// 			return (true);
+// 		headlocation_iter++;
+// 	}
+// 	return (false);
+// }
 
-bool
-Server::checkHttpConfigFilePath(std::string path, std::string method)
-{
-	int path_length = path.length();
-	if (method == "HEAD")
-	{
-		if (checkHttpConfigFilePathHead(path))
-			return (false);
-		return (true);
-	}
-	std::vector<std::string>::const_iterator path_iter = this->m_httpConfigFilePathSet.begin();
-	while (path_iter != this->m_httpConfigFilePathSet.end())
-	{
-		int path_iter_length = (*path_iter).length();
-		if (path == *path_iter)
-			return (false);
-		if (path_length > path_iter_length
-		&& path_iter_length > 1
-		&& path.substr(0, path_iter_length) == *path_iter)
-			return (false);
-		path_iter++;
-	}
-	return (true);
-}
+// bool
+// Server::checkHttpConfigFilePath(std::string path, std::string method)
+// {
+// 	int path_length = path.length();
+// 	if (method == "HEAD")
+// 	{
+// 		if (checkHttpConfigFilePathHead(path))
+// 			return (false);
+// 		return (true);
+// 	}
+// 	std::vector<std::string>::const_iterator path_iter = this->m_httpConfigFilePathSet.begin();
+// 	while (path_iter != this->m_httpConfigFilePathSet.end())
+// 	{
+// 		int path_iter_length = (*path_iter).length();
+// 		if (path == *path_iter)
+// 			return (false);
+// 		if (path_length > path_iter_length
+// 		&& path_iter_length > 1
+// 		&& path.substr(0, path_iter_length) == *path_iter)
+// 			return (false);
+// 		path_iter++;
+// 	}
+// 	return (true);
+// }
 
 Response
 Server::methodGET(int clientfd, std::string method)
@@ -653,8 +670,8 @@ Server::methodGET(int clientfd, std::string method)
 	** 현재 60초 이상 경과되면 200 아니면 304 response message
 	** ft::compareTimestampToCurrent("현재 시간")
 	*/
-	if (ft::compareTimestampToCurrent("Wed, 24 Mar 2021 14:24:57 KST") > 60)
-		return (makeResponseBodyMessage(304, "", method));
+	// if (ft::compareTimestampToCurrent("Wed, 24 Mar 2021 14:24:57 KST") > 60)
+	// 	return (makeResponseBodyMessage(304, "", method));
 
 	/* map < path, autoindex 여부 > 예시 */
 	std::map<std::string, bool>::iterator iter;
@@ -926,8 +943,6 @@ Server::methodPOST(int clientfd)
 	// 	// 	response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::HttpConfigPost);
 	// 	location_iter++;
 	// }
-	if(checkHttpConfigFilePath(this->m_requests[clientfd].get_m_uri().get_m_path()))
-		return (Server::makeResponseMessage(405, ""));
 	return (Server::makeResponseMessage(405, ""));
 }
 
@@ -945,8 +960,6 @@ Server::methodPUT(int clientfd)
 	int status_code = 0;
 
 	/* cgi part should be added */
-	if(checkHttpConfigFilePath(path))
-		return (Server::makeResponseMessage(405, ""));
 	std::cout << this->m_root + path << std::endl;
 	if (ft::isValidFilePath(this->m_root + path) == false)
 	{
@@ -1301,12 +1314,7 @@ Server::methodNotImplemented_501()
 Response
 Server::parseErrorResponse(int clientfd)
 {
-	if (this->m_requests[clientfd].get_m_error_code() == 400)
-		return (badRequest_400());
-	else if (this->m_requests[clientfd].get_m_error_code() == 501)
-		return (methodNotImplemented_501());
-	else
-		return (page404(this->m_err_page_path));
+	return (makeResponseBodyMessage(this->m_requests[clientfd].get_m_error_code()));
 }
 
 Response
@@ -1395,35 +1403,39 @@ Server::sendResponse(int clientfd)
 
 	/* make Response for Parse Error */
 	if (this->m_requests[clientfd].get_m_error_code())
-		response = this->parseErrorResponse(clientfd);
-
-	/* make Response for Method */
-	switch(method)
 	{
-	case GET:
-		response = this->methodGET(clientfd);
-		break;
-	case HEAD:
-		response = this->methodHEAD(clientfd);
-		break;
-	case POST:
-		response = this->methodPOST(clientfd);
-		break;
-	case PUT:
-		response = this->methodPUT(clientfd);
-		break;
-	case DELETE:
-		response = this->methodDELETE(clientfd);
-		break;
-	case TRACE:
-		response = this->methodTRACE(clientfd);
-		break;
-	case OPTIONS:
-		response = this->methodOPTIONS(clientfd);
-		break;
-	default:
-		response = methodNotAllow_405();
-		break;
+		response = this->parseErrorResponse(clientfd);
+	}
+	else
+	{
+	/* make Response for Method */
+		switch(method)
+		{
+		case GET:
+			response = this->methodGET(clientfd);
+			break;
+		case HEAD:
+			response = this->methodHEAD(clientfd);
+			break;
+		case POST:
+			response = this->methodPOST(clientfd);
+			break;
+		case PUT:
+			response = this->methodPUT(clientfd);
+			break;
+		case DELETE:
+			response = this->methodDELETE(clientfd);
+			break;
+		case TRACE:
+			response = this->methodTRACE(clientfd);
+			break;
+		case OPTIONS:
+			response = this->methodOPTIONS(clientfd);
+			break;
+		default:
+			response = methodNotAllow_405();
+			break;
+		}
 	}
 	/* config Method */
 	// response = get("/hi", this->m_requests[clientfd], response, Server::getDirectory);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -467,7 +467,7 @@ Server::getMethodLocation(Method method)
 }
 
 bool
-isMatchingLocation(std::string location, std::string path_in, std::string *rest)
+Server::isMatchingLocation(std::string location, std::string path_in, std::string *rest)
 {
 	try
 	{


### PR DESCRIPTION
resetRequest()는 config를 반영해 path를 재해석합니다.
로직은 다음과 같습니다. 

- 일반적인 메소드(get, head, post, put, delete, options, trace)인지 확인하고 아니라면 405
- 해당 method location block(ex. get이라면 m_getLocation)에 매칭되는 로케이션이 있는지 확인합니다
- 매칭된 것 중 가장 긴 로케이션 path를 기준으로 그 로케이션블록의 root를 반영해 path를 재설정합니다
- 만약 탐색한 method location block에는 없지만 매칭되는 로케이션 블록이 있는지 확인해, 다른 메소드만을 허용하는 거라면 405를 반환합니다
- path는 request.m_reset_path로 저장돼 있습니다. 