### PR TITLE
[FEAT] update makeErrorPage

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -44,7 +44,6 @@ class Server
 		HttpConfigServer m_server_block;
 		std::string m_server_name;
 		int m_port;
-		std::string m_err_page_path;
 		int m_content_length;
 		size_t m_location_size;
 		std::string m_root;
@@ -97,7 +96,6 @@ class Server
 			HttpConfigServer server_block,
 			std::string server_name,
 			int port,
-			std::string err_page_path,
 			int content_length,
 			size_t location_size,
 			std::string root,

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -36,7 +36,6 @@ class ServerManager
 			HttpConfigServer server_block,
 			std::string server_name,
 			int port,
-			std::string err_page_path,
 			int content_length,
 			size_t location_size,
 			std::string root,

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -10,7 +10,7 @@
 
 Response::Response()
 :m_status_code(404), m_date(""), m_content_language("ko, en"), m_content_type("text/html; charset=UTF-8"),
-m_server("ftnix/1.0 (MacOS)"), m_status_description(""), m_headers(), m_html_document(""), m_body(""),
+m_server("ftinx/1.0 (MacOS)"), m_status_description(""), m_headers(), m_html_document(""), m_body(""),
 m_head(""), m_content_length(0), m_response_message(""), m_response_size(0), m_index_file(),
 m_err_page_path("./www/errors/default_error.html"), m_root(""), m_cgi_extension(), m_cgi_server_name(""),
 m_cgi_client_addr(), m_cgi_port(0)
@@ -326,7 +326,7 @@ Response::set404HtmlDocument()
 					+ std::string("</head>")
 					+ std::string("<body>")
 						+ std::string("<p>404 Not Found</p>")
-						+ std::string("<p>- ftnix/1.0 -</p>")
+						+ std::string("<p>- ftinx/1.0 -</p>")
 					+ std::string("</body>")
 				+ std::string("</html>");
 	return (body);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -22,7 +22,6 @@ Server& Server::operator=(Server const &rhs)
 	this->m_server_block = rhs.m_server_block;
 	this->m_server_name = rhs.m_server_name;
 	this->m_port = rhs.m_port;
-	this->m_err_page_path = rhs.m_err_page_path;
 	this->m_content_length = rhs.m_content_length;
 	this->m_location_size = rhs.m_location_size;
 	this->m_root = rhs.m_root;
@@ -175,17 +174,13 @@ Server::noteHttpConfigLocation()
 }
 
 void
-Server::init(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size, std::string root, std::map<std::string, std::string> mime_types)
+Server::init(HttpConfigServer server_block, std::string server_name, int port, int content_length, size_t location_size, std::string root, std::map<std::string, std::string> mime_types)
 {
 	this->m_requests = std::vector<Request>(MAX_SOCK_NUM);
 	this->m_responses = std::vector<Response>(MAX_SOCK_NUM);
 	this->m_server_block = server_block;
 	this->m_server_name = server_name;
 	this->m_port = port;
-	if (err_page_path != "")
-		this->m_err_page_path = err_page_path;
-	else
-		this->m_err_page_path = "./www/errors/default_error.html";
 	this->m_content_length = content_length;
 	this->m_location_size = location_size;
 	this->m_root = root;
@@ -997,13 +992,17 @@ Server::methodPUT(int clientfd, std::string method)
 	{
 		std::cout << "PATH: " << path << std::endl;
 		if ((fd = open((path).c_str(), O_RDWR | O_CREAT, 0666)) < 0)
+		{
  			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		}
 		status_code = 201;
 	}
 	else
 	{
 		if ((fd = open((path).c_str(), O_RDWR | O_TRUNC, 0666)) < 0)
+		{
 			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		}
 		status_code = 200;
 	}
 	body = req.get_m_body().c_str();
@@ -1067,7 +1066,7 @@ Server::methodOPTIONS(int clientfd, std::string method)
 	if (location.get_m_path() == "") // 초기화된 상태 그대로, 맞는 로케이션 블록 못찾았을 때 값
 		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
 	allow_method = makeAllowMethod(location.get_m_limit_except());
-	return (makeResponseBodyMessage(204, "", method, "text/html; charset=UTF-8", 0, 0, 0, allow_method));
+	return (Server::makeResponseBodyMessage(204, "", method, "text/html; charset=UTF-8", 0, 0, 0, allow_method));
 }
 
 
@@ -1223,7 +1222,7 @@ Server::getDirectory(Request req, Response res)
 			.setCurrentDate()
 			.setContentLanguage("ko, en")
 			.setContentType("text/html; charset=UTF-8")
-			.setServer("ftnix/1.0 (MacOS)")
+			.setServer("ftinx/1.0 (MacOS)")
 			.setPublicFileDocument("index.html")
 			.setHttpResponseHeader("date", response.get_m_date())
 			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -80,10 +80,10 @@ ServerManager::parseHttpConfig(std::string config_path)
 }
 
 Server
-ServerManager::generateServer(HttpConfigServer server_block, std::string server_name, int port, std::string err_page_path, int content_length, size_t location_size, std::string root, std::map<std::string, std::string> mime_types)
+ServerManager::generateServer(HttpConfigServer server_block, std::string server_name, int port, int content_length, size_t location_size, std::string root, std::map<std::string, std::string> mime_types)
 {
 	Server server;
-	server.init(server_block, server_name, port, err_page_path, content_length,location_size, root, mime_types);
+	server.init(server_block, server_name, port, content_length,location_size, root, mime_types);
 	server.setServerAddr(port);
 	server.setServerSocket();
 	server.noteHttpConfigLocation();
@@ -99,7 +99,6 @@ ServerManager::initServers()
 				this->m_server_block[i],
 				this->m_server_block[i].get_m_server_name(),
 				this->m_server_block[i].get_m_listen(),
-				this->m_server_block[i].get_m_default_error_page(),
 				this->m_server_block[i].get_m_content_length(),
 				this->m_server_block[i].get_m_location_block().size(),
 				this->m_root,

--- a/www/errors/default_error.html
+++ b/www/errors/default_error.html
@@ -4,14 +4,14 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link rel="stylesheet" href="style.css">
+	<link rel="stylesheet" href="./style.css">
 	<title>Webserv</title>
 </head>
 <body>
 	<div class="indexContainer">
 		<h1>404 Error</h1>
 		<img src="../imgs/favicon.jpg" height="100px" />
-		<p>ftnix made by holee jwon yechoi</p>
+		<p>ftinx made by holee jwon yechoi</p>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
- 기본 에러페이지도 `makeErrorPage` 함수에서 처리, 존재할 경우 스트링으로 변환하여 사용

```c++
std::string
Server::makeErrorPage(int status_code)
{
..
	if (this->m_server_block.get_m_default_error_page().empty() == false) // config 파일에 에러페이지 존재할 경우
	{
		std::string path(this->m_root + this->m_server_block.get_m_default_error_page());
		if (ft::isValidFilePath(path)) // 존재하는 정상적인 파일이라면
			return (ft::fileToString(path)); // string 으로 변환 후 반환
	}
..
}
```

- 에러페이지 반환이 필요한 곳에 위 함수 적용
- `Server.cpp` 에 `m_err_page_path` 멤버변수 삭제, 연동되어 있는 모든 곳 수정
- ftnix -> ftinx 수정