### PR TITLE
[FEAT] updated logic before executeCgi() #39

### DIFF
--- a/ftinx_sample_yechoi_cluster.conf
+++ b/ftinx_sample_yechoi_cluster.conf
@@ -17,7 +17,7 @@ http {
             autoindex on
         }
         location /put_test {
-            limit_except PUT
+            limit_except PUT POST
             root /Users/yechoi/42cursus/webserv/tests/put_test
             cgi .bla
             cgi_path /Users/yechoi/42cursus/webserv/cgi_tester

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -70,6 +70,7 @@ class Request
 		bool checkBlankLine(std::string);
 		bool parseBody(std::string, int, int, bool);
 		void checkChunked(std::string);
+		std::string findPathInfo();
 		void printHeaders() const;
 };
 

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -28,6 +28,9 @@ class Request
 		int m_error_code;
 		std::string m_reset_path;
 		HttpConfigLocation m_location_block;
+		/* cgi envp */
+		std::string m_path_translated;
+		std::string m_path_info;
 
 	public:
 		Request();
@@ -47,6 +50,8 @@ class Request
 		int	get_m_error_code() const;
 		std::string get_m_reset_path() const;
 		HttpConfigLocation get_m_location_block() const;
+		std::string get_m_path_translated() const;
+		std::string get_m_path_info() const;
 		void set_m_http_version(std::string);
 		void set_m_cgi_version(std::string);
 		void set_m_check_cgi(bool);
@@ -65,12 +70,12 @@ class Request
 		bool parseMessage(bool);
 		bool parseRequestLine(std::string);
 		bool checkMethod();
-		bool checkCGI();
 		bool parseHeader(std::string);
 		bool checkBlankLine(std::string);
 		bool parseBody(std::string, int, int, bool);
 		void checkChunked(std::string);
-		std::string findPathInfo();
+		std::string getRestPath();
+		bool checkCGI();
 		void printHeaders() const;
 };
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -445,6 +445,13 @@ Request::checkBlankLine(std::string str)
 	return (false);
 }
 
+std::string
+Request::getPathInfo()
+{
+
+}
+
+
 void
 Request::printHeaders() const
 {

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -9,7 +9,7 @@
 Request::Request()
 : m_message(""), m_http_version(""), m_cgi_version(""), m_check_cgi(false),
 m_method(DEFAULT), m_uri(), m_headers(), m_body(""), m_error_code(0),
-m_reset_path(""), m_location_block()
+m_reset_path(""), m_location_block(), m_path_translated(""), m_path_info("")
 {
 }
 
@@ -33,6 +33,8 @@ Request& Request::operator=(Request const &rhs)
 	this->m_error_code = rhs.get_m_error_code();
 	this->m_reset_path = rhs.get_m_reset_path();
 	this->m_location_block = rhs.get_m_location_block();
+	this->m_path_translated = rhs.get_m_path_translated();
+	this->m_path_info = rhs.get_m_path_info();
 	return (*this);
 }
 
@@ -93,7 +95,6 @@ Request::get_m_headers() const
 	return (this->m_headers);
 }
 
-
 std::string
 Request::get_m_body() const
 {
@@ -116,6 +117,18 @@ HttpConfigLocation
 Request::get_m_location_block() const
 {
 	return (this->m_location_block);
+}
+
+std::string
+Request::get_m_path_translated() const
+{
+	return (this->m_path_translated);
+}
+
+std::string
+Request::get_m_path_info() const
+{
+	return (this->m_path_info);
 }
 
 /*============================================================================*/
@@ -354,7 +367,6 @@ Request::parseRequestLine(std::string request_line)
 		this->m_error_code = error_code;
 		return(false);
 	}
-	checkCGI();
 	return (true);
 }
 
@@ -423,21 +435,6 @@ Request::checkMethod()
 }
 
 bool
-Request::checkCGI()
-{
-	size_t pos;
-	std::string path = std::string(".") + this->m_uri.get_m_path();
-
-	pos = path.find("cgi-bin");
-	if (pos != 0)
-		return (this->m_check_cgi = false);
-	if (ft::isValidFilePath(path))
-		return (this->m_check_cgi = true);
-	else
-		return (this->m_check_cgi = false);
-}
-
-bool
 Request::checkBlankLine(std::string str)
 {
 	if (str[0] == '\r')
@@ -446,11 +443,48 @@ Request::checkBlankLine(std::string str)
 }
 
 std::string
-Request::getPathInfo()
+Request::getRestPath()
 {
+	std::vector<std::string> v(m_location_block.get_m_cgi());
+	std::vector<std::string>::const_iterator it;
+	size_t pos;
 
+	for (it = v.begin(); it != v.end(); it++)
+	{
+		if ((pos = m_reset_path.find(*it)) != std::string::npos)
+		{
+			return (m_reset_path.substr(pos + (*it).size(), std::string::npos));
+		}
+	}
+	return ("");
 }
 
+bool
+Request::checkCGI()
+{
+	std::string path(m_reset_path);
+	HttpConfigLocation loc(m_location_block);
+	size_t pos;
+
+	if (ft::checkValidFileExtension(path, loc.get_m_cgi()))
+	{
+		if (ft::isValidFilePath(path))
+		{
+			this->m_path_translated = path;
+			path = path.substr(0, m_location_block.get_m_root().size());
+			if ((pos = path.find_first_of("/")) != std::string::npos)
+				path = path.substr(pos + 1, std::string::npos);
+			this->m_path_info = path;
+		}
+		else
+		{
+			this->m_path_translated = loc.get_m_cgi_path();
+			this->m_path_info = getRestPath();
+		}
+		return (true);
+	}
+	return (false);
+}
 
 void
 Request::printHeaders() const

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -790,9 +790,10 @@ Server::makeCgiEnvpMap(Request req, Response res)
 	map["SERVER_PROTOCOL"] = req.get_m_http_version();
 	map["SERVER_PORT"] = std::to_string(res.get_m_cgi_port());
 	map["REQUEST_METHOD"] = req.getMethod();
-	//map["PATH_INFO"] = this->parseCgiPathInfo(req);
-	// map["PATH_INFO"] = "/cgi-bin/cgi_tester";
-	map["PATH_TRANSLATED"] = uri.get_m_path();
+	map["PATH_INFO"] = req.findPathInfo();
+	map["PATH_TRANSLATED"] = req.get_m_reset_path();
+	map["REDIRECT_STATUS"] = "";
+	map["SCRIPT_FILENAME"] = "";
 	map["SCRIPT_NAME"] = uri.get_m_path();
 	map["QUERY_STRING"] = uri.get_m_query_string();
 	map["REMOTE_ADDR"] = ft::iNetNtoA(res.get_m_cgi_client_addr());

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -837,7 +837,7 @@ Server::executeCgi(Request req, Response res, std::string method)
 		dup2(cgi_stdout, STDOUT_FILENO);
 		dup2(cgi_stdin, STDIN_FILENO);
 		// 일반화 해줘야
-		ret = execve("./cgi-bin/cgi_tester", 0, envp);
+		ret = execve(req.get_m_path_translated().c_str(), 0, envp);
 		exit(ret);
 	}
 	else
@@ -917,6 +917,7 @@ Server::methodPOST(int clientfd, std::string method)
 
 	if (request.checkCGI() == true)
 	{
+		std::cout << "##### START CGI PART #####" << std::endl;
 		executeCgi(request, response, method);
 	}
 	return (response);
@@ -962,13 +963,8 @@ Server::methodPOST(int clientfd, std::string method)
 	// 	// 	response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::HttpConfigPost);
 	// 	location_iter++;
 	// }
-<<<<<<< HEAD
-// 	return (Server::makeResponseMessage(405, "", method));
+// 	return (Server::makeResponseBodyMessage(405, makeErrorPage(405), method));
 // }
-=======
-	return (Server::makeResponseBodyMessage(405, makeErrorPage(405), method));
-}
->>>>>>> a2a9a694f90a354a69aa161a04a2c21dbef8be12
 
 /*============================================================================*/
 /**********************************  PUT  *************************************/

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -472,16 +472,16 @@ checkValidFileExtension(std::string file_name, std::string ext)
 bool
 checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list)
 {
-	std::vector<std::string> tmp;
+	std::vector<std::string>::const_iterator it;
 	std::string extension;
+	size_t pos;
 
-	if (file_name.find_last_of(".") == std::string::npos)
+	if ((pos = file_name.find_last_of(".")) == std::string::npos)
 		return (false);
-	tmp = ft::split(file_name, '.');
-	extension = tmp.back();
-	for (size_t i = 0 ; i < ext_list.size() ; i++)
+	extension = file_name.substr(pos, std::string::npos);
+	for (it = ext_list.begin() ; it != ext_list.end() ; it++)
 	{
-		if (ext_list[i].compare(extension) == 0)
+		if (*it == extension)
 			return (true);
 	}
 	return (false);

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -460,7 +460,7 @@ checkValidFileExtension(std::string file_name, std::string ext)
 	std::vector<std::string> tmp;
 	std::string extension;
 
-	if (file_name.find(".") == std::string::npos)
+	if (file_name.find_last_of(".") == std::string::npos)
 		return (false);
 	tmp = ft::split(file_name, '.');
 	extension = tmp.back();
@@ -475,7 +475,7 @@ checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list
 	std::vector<std::string> tmp;
 	std::string extension;
 
-	if (file_name.find(".") == std::string::npos)
+	if (file_name.find_last_of(".") == std::string::npos)
 		return (false);
 	tmp = ft::split(file_name, '.');
 	extension = tmp.back();


### PR DESCRIPTION
CGI 실행(executeCgi())이전의 로직인 checkCGI()를 만들었습니다. (기존에도 함수명은 있었지만 내용이 많이 달라졌습니다.)
목적은 CGI를 실행하는 데 있어 올바른 경로(PATH_TRANSLATED)를 찾고, 환경변수에 필요한 PATH_INFO 변수를 찾는 것입니다.
이 부분은 모두 `Request::checkCgi()`에서 이뤄집니다. 이 함수는 원하는 메소드에서 아래와 같이 사용하면 됩니다.

```c++
Response
Server::methodPOST(int clientfd, std::string method)
{
	Response response;
	Request request(m_requests[clientfd]);

	if (request.checkCGI() == true)
	{
             /*CGI 실행부 */
	}
        else
       {
            /*CGI 외 로직 실행부*/
        }
```

CheckCgi는 다음과 같이 동작합니다. 
1. 먼저 location block에서 지정한 cgi extension 인지 확인합니다. 아니라면 False를 뱉습니다.
2. 맞다면 m_reset_path 기준으로 실제 이 실행파일이 존재하는지 확인합니다.
2-1. 존재한다면 m_reset_path 기준으로 m_path_translated, m_path_info를 설정합니다.
2-2. 존재하지 않는다면 location block의 cgi path를 기준으로 m_path_translated, m_path_info를 설정합니다.