### PR TITLE
[FEAT] add headers, Server (#185)

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -115,13 +115,17 @@ class Server
 		static Response makeResponseMessage(
 			int statusCode,
 			std::string path="./www/index.html", std::string method="", std::string contentType="text/html; charset=UTF-8",
+			std::string referer="",
 			int dateHour=0, int dateMinute=0, int dateSecond=0, std::string allow_method="", std::string content_location="",
+			std::string location="./www/index.html",
 			std::string contentLanguage="ko, en", std::string server="ftnix/1.0 (MacOS)"
 		);
 		static Response makeResponseBodyMessage(
 			int statusCode,
 			std::string body="", std::string method="", std::string contentType="text/html; charset=UTF-8",
+			std::string referer,
 			int dateHour=0, int dateMinute=0, int dateSecond=0, std::string allow_method="", std::string content_location="",
+			std::string location="./www/index.html",
 			std::string contentLanguage="ko, en", std::string server="ftnix/1.0 (MacOS)"
 		);
 		void sendResponse(int clientfd);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -123,7 +123,7 @@ class Server
 		static Response makeResponseBodyMessage(
 			int statusCode,
 			std::string body="", std::string transfer_encoding="", std::string method="", std::string contentType="text/html; charset=UTF-8",
-			std::string referer,
+			std::string referer="",
 			int dateHour=0, int dateMinute=0, int dateSecond=0, std::string allow_method="", std::string content_location="",
 			std::string location="./www/index.html",
 			std::string contentLanguage="ko, en", std::string server="ftnix/1.0 (MacOS)"

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -128,6 +128,8 @@ class Server
 		);
 		void sendResponse(int clientfd);
 		Response parseErrorResponse(int clientfd);
+		Response checkValidRequestHeader(int clientfd);
+
 		// bool checkHttpConfigFilePath(std::string path, std::string method="");
 		// bool checkHttpConfigFilePathHead(std::string path);
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -114,7 +114,7 @@ class Server
 		void resetRequest(Request *req);
 		static Response makeResponseMessage(
 			int statusCode,
-			std::string path="./www/index.html", std::string method="", std::string contentType="text/html; charset=UTF-8",
+			std::string path="./www/index.html", std::string transfer_encoding="", std::string method="", std::string contentType="text/html; charset=UTF-8",
 			std::string referer="",
 			int dateHour=0, int dateMinute=0, int dateSecond=0, std::string allow_method="", std::string content_location="",
 			std::string location="./www/index.html",
@@ -122,7 +122,7 @@ class Server
 		);
 		static Response makeResponseBodyMessage(
 			int statusCode,
-			std::string body="", std::string method="", std::string contentType="text/html; charset=UTF-8",
+			std::string body="", std::string transfer_encoding="", std::string method="", std::string contentType="text/html; charset=UTF-8",
 			std::string referer,
 			int dateHour=0, int dateMinute=0, int dateSecond=0, std::string allow_method="", std::string content_location="",
 			std::string location="./www/index.html",

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -375,18 +375,16 @@ Request::parseHeader(std::string line)
 		this->m_error_code = 400;
 		return (false);
 	}
-	if (key_value[0] == "Host")
+	if (key_value[0] == "Host" || key_value[0] == "host")
 		this->m_uri.set_m_host(ft::trim(key_value[1], " "));
-	else if (key_value[0] == "Port")
+	else if (key_value[0] == "Port" || key_value[0] == "port")
 		this->m_uri.set_m_port(ft::trim(key_value[1], " "));
-	else
+
+	if (this->m_headers.insert(make_pair(key_value[0], ft::trim(key_value[1], " "))).second == false
+	&& (key_value[0] == "Host" || key_value[0] == "host" ))
 	{
-		if (this->m_headers.insert(make_pair(key_value[0], ft::trim(key_value[1], " "))) == false
-		&& key_value[0] == "Host")
-		{
-			this->m_error_code = 400;
-			return (false);
-		}
+		this->m_error_code = 400;
+		return (false);
 	}
 	return (true);
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -380,7 +380,14 @@ Request::parseHeader(std::string line)
 	else if (key_value[0] == "Port")
 		this->m_uri.set_m_port(ft::trim(key_value[1], " "));
 	else
-		this->m_headers.insert(make_pair(key_value[0], ft::trim(key_value[1], " ")));
+	{
+		if (this->m_headers.insert(make_pair(key_value[0], ft::trim(key_value[1], " "))) == false
+		&& key_value[0] == "Host")
+		{
+			this->m_error_code = 400;
+			return (false);
+		}
+	}
 	return (true);
 }
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -314,24 +314,6 @@ Response::setHtmlAttribute(htmlTag tag, std::string value)
 	return (*this);
 }
 
-std::string
-Response::set404HtmlDocument()
-{
-	std::string body;
-
-	body += std::string("<!DOCTYPE html>")
-				+ std::string("<html lang=\"en\">")
-					+ std::string("<head>")
-						+ this->m_head
-					+ std::string("</head>")
-					+ std::string("<body>")
-						+ std::string("<p>404 Not Found</p>")
-						+ std::string("<p>- ftinx/1.0 -</p>")
-					+ std::string("</body>")
-				+ std::string("</html>");
-	return (body);
-}
-
 Response &
 Response::setBodyDocument(std::string body)
 {
@@ -371,22 +353,16 @@ Response::setHtmlDocument()
 {
 	std::string body;
 
-	if (this->m_status_code == 404)
-	{
-		body += set404HtmlDocument();
-	}
-	else
-	{
-		body += std::string("<!DOCTYPE html>")
-					+ std::string("<html lang=\"en\">")
-						+ std::string("<head>")
-							+ this->m_head
-						+ std::string("</head>")
-						+ std::string("<body>")
-							+ this->m_body
-						+ std::string("</body>")
-					+ std::string("</html>");
-	}
+	body += std::string("<!DOCTYPE html>")
+				+ std::string("<html lang=\"en\">")
+					+ std::string("<head>")
+						+ this->m_head
+					+ std::string("</head>")
+					+ std::string("<body>")
+						+ this->m_body
+					+ std::string("</body>")
+				+ std::string("</html>");
+
 	this->m_html_document = body;
 	this->m_content_length = body.length();
 	return (*this);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1084,19 +1084,17 @@ Server::makeResponseMessage(
 {
 	Response response = Response();
 
+	if (statusCode == 301 || statusCode == 503)
+		response.setHttpResponseHeader("retry-after", 10);
+
 	if (method == "GET")
 		response.setHttpResponseHeader("last-modified", response.get_m_date());
 	else if (method == "POST")
-	{
 		response.setHttpResponseHeader("content-location", content_location);
-	}
 	else if (method == "PUT")
-	{
 		response.setHttpResponseHeader("content-location", content_location);
-	}
 	else if (method == "OPTIONS")
 		response.setHttpResponseHeader("allow", allow_method);
-
 	return (
 		response
 			.setStatusCode(statusCode)
@@ -1124,16 +1122,15 @@ Server::makeResponseBodyMessage(
 {
 	Response response = Response();
 
+	if (statusCode == 301 || statusCode == 503)
+		response.setHttpResponseHeader("retry-after", 10);
+
 	if (method == "TRACE")
 		response.setHttpResponseHeader("connection", "close");
 	else if (method == "POST")
-	{
 		response.setHttpResponseHeader("content-location", content_location);
-	}
 	else if (method == "PUT")
-	{
 		response.setHttpResponseHeader("content-location", content_location);
-	}
 	else if (method == "OPTIONS")
 		response.setHttpResponseHeader("allow", allow_method);
 	return (

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1214,6 +1214,15 @@ Server::parseErrorResponse(int clientfd)
 }
 
 Response
+Server::checkValidRequestHeader(int clientfd)
+{
+	int status_code(this->m_requests[clientfd].get_m_error_code());
+	return (
+		Server::makeResponseBodyMessage(400, makeErrorPage(400))
+	);
+}
+
+Response
 Server::getDirectory(Request req, Response res)
 {
 	Response response = Response();
@@ -1299,9 +1308,7 @@ Server::sendResponse(int clientfd)
 
 	/* make Response for Parse Error */
 	if (this->m_requests[clientfd].get_m_error_code())
-	{
 		response = this->parseErrorResponse(clientfd);
-	}
 	else
 	{
 	/* make Response for Method */

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1077,7 +1077,7 @@ Server::methodTRACE(int clientfd, std::string method)
 
 Response
 Server::makeResponseMessage(
-	int statusCode, std::string path, bool transfer_encoding, std::string method, std::string contentType,
+	int statusCode, std::string path, std::string transfer_encoding, std::string method, std::string contentType,
 	std::string referer,
 	int dateHour, int dateMinute, int dateSecond, std::string allow_method, std::string content_location,
 	std::string location,
@@ -1125,7 +1125,7 @@ Server::makeResponseMessage(
 
 Response
 Server::makeResponseBodyMessage(
-	int statusCode, std::string body, std::string method, bool transfer_encoding, std::string contentType,
+	int statusCode, std::string body, std::string transfer_encoding, std::string method, std::string contentType,
 	std::string referer,
 	int dateHour, int dateMinute, int dateSecond, std::string allow_method, std::string content_location,
 	std::string location,

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -713,14 +713,14 @@ Server::methodGET(int clientfd, std::string method)
 			{
 				extension = (*index_it).substr((*index_it).find_last_of(".") + 1, std::string::npos);
 				type = getMimeType(extension);
-				return (Server::makeResponseMessage(200, absolute_path + *index_it, method, type)); // 200 응답과 반환
+				return (Server::makeResponseMessage(200, absolute_path + *index_it, "", method, type)); // 200 응답과 반환
 			}
 		}
 		std::map<std::string, bool>::const_iterator autoindex_it;
 		for (autoindex_it = this->m_getLocationAutoIndex.begin() ; autoindex_it != this->m_getLocationAutoIndex.end() ; ++autoindex_it)
 		{
 			if (location_block.get_m_path().compare((*autoindex_it).first) == 0 && (*autoindex_it).second == true)
-				return (Server::makeResponseBodyMessage(200, makeAutoindexPage(location_block.get_m_root(), absolute_path), method));
+				return (Server::makeResponseBodyMessage(200, makeAutoindexPage(location_block.get_m_root(), absolute_path), "", method));
 		}
 	}
 	else // 폴더가 아니라면
@@ -729,10 +729,10 @@ Server::methodGET(int clientfd, std::string method)
 		{
 			extension = absolute_path.substr(absolute_path.find_last_of(".") + 1, std::string::npos);
 			type = getMimeType(extension);
-			return (Server::makeResponseMessage(200, absolute_path, method, type));
+			return (Server::makeResponseMessage(200, absolute_path, "", method, type));
 		}
 	}
-	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 }
 
 
@@ -812,7 +812,7 @@ Server::executeCgi(Request req, Response res, std::string method)
 
 	std::cout << "Execute Cgi >0<" << std::endl;
 	if (pipe(pipe1) < 0 || pipe(pipe2) < 0)
-		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 
 	int parent_stdout = pipe1[1];
 	int parent_stdin = pipe2[0];
@@ -828,7 +828,7 @@ Server::executeCgi(Request req, Response res, std::string method)
 	fcntl(parent_stdin, F_SETFL, O_NONBLOCK);
 
 	if ((pid = fork()) < 0)
-		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 	if (pid == 0)
 	{
 		close(parent_stdout);
@@ -887,9 +887,9 @@ Server::postAuth(Request req, Response res)
 			printf("::%d:: ::%d::", username == "42seoul", password == "42seoul");
 
 			if (username == "42seoul" && password == "42seoul")
-				return (Server::makeResponseMessage(200, "./www/srcs/login.html"));
+				return (Server::makeResponseMessage(200, "./www/srcs/login.html", ""));
 			else
-				return (Server::makeResponseMessage(200, "./www/index.html"));
+				return (Server::makeResponseMessage(200, "./www/index.html", ""));
 		}
 	}
 	return (res);
@@ -904,7 +904,7 @@ Server::HttpConfigPost(Request req, Response res)
 
 	/* Response */
 	return (
-		Server::makeResponseMessage(200)
+		Server::makeResponseMessage(200, "./www/index.html", "")
 	);
 }
 
@@ -948,7 +948,7 @@ Server::methodPOST(int clientfd, std::string method)
 	// 	// 	response = post(location_iter->get_m_path(), this->m_requests[clientfd], response, Server::HttpConfigPost);
 	// 	location_iter++;
 	// }
-	return (Server::makeResponseBodyMessage(405, makeErrorPage(405), method));
+	return (Server::makeResponseBodyMessage(405, makeErrorPage(405), "", method));
 }
 
 /*============================================================================*/
@@ -971,7 +971,7 @@ Server::methodPUT(int clientfd, std::string method)
 		std::cout << "PATH: " << path << std::endl;
 		if ((fd = open((path).c_str(), O_RDWR | O_CREAT, 0666)) < 0)
 		{
- 			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+ 			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 		}
 		status_code = 201;
 	}
@@ -979,7 +979,7 @@ Server::methodPUT(int clientfd, std::string method)
 	{
 		if ((fd = open((path).c_str(), O_RDWR | O_TRUNC, 0666)) < 0)
 		{
-			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+			return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 		}
 		status_code = 200;
 	}
@@ -987,14 +987,14 @@ Server::methodPUT(int clientfd, std::string method)
 	if (write(fd, req.get_m_body().c_str(), ft::strlen(req.get_m_body().c_str())) < 0)
 	{
 		close(fd);
-		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 	}
 	else
 	{
 		close(fd);
 		return (Server::makeResponseBodyMessage(status_code, "", method));
 	}
-	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 }
 
 /*============================================================================*/
@@ -1009,9 +1009,9 @@ Server::methodDELETE(int clientfd, std::string method)
 	if (ft::isValidFilePath(path))
 	{
 		if (unlink(path.c_str()) == 0)
-			return (Server::makeResponseMessage(200, "./www/index.html", method));
+			return (Server::makeResponseMessage(200, "./www/index.html", "", method));
 	}
-	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+	return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 }
 
 /*============================================================================*/
@@ -1042,9 +1042,9 @@ Server::methodOPTIONS(int clientfd, std::string method)
 	HttpConfigLocation location = m_requests[clientfd].get_m_location_block();
 
 	if (location.get_m_path() == "") // 초기화된 상태 그대로, 맞는 로케이션 블록 못찾았을 때 값
-		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), method));
+		return (Server::makeResponseBodyMessage(404, makeErrorPage(404), "", method));
 	allow_method = makeAllowMethod(location.get_m_limit_except());
-	return (Server::makeResponseBodyMessage(204, "", method, "text/html; charset=UTF-8", "", 0, 0, 0, allow_method));
+	return (Server::makeResponseBodyMessage(204, "",  "", method, "text/html; charset=UTF-8", "", 0, 0, 0, allow_method));
 }
 
 
@@ -1067,7 +1067,7 @@ Server::methodTRACE(int clientfd, std::string method)
 	Response response = Response();
 
 	return (
-		Server::makeResponseBodyMessage(200, this->m_requests[clientfd].get_m_message(), method, "message/http")
+		Server::makeResponseBodyMessage(200, this->m_requests[clientfd].get_m_message(), "", method, "message/http")
 	);
 }
 
@@ -1088,8 +1088,8 @@ Server::makeResponseMessage(
 	Response response = Response();
 
 	if (statusCode == 301 || statusCode == 503)
-		response.setHttpResponseHeader("retry-after", 10);
-	if (300 <= statusCode < 400 || statusCode == 201)
+		response.setHttpResponseHeader("retry-after", "10");
+	if ((300 <= statusCode && statusCode < 400) || statusCode == 201)
 		response.setHttpResponseHeader("location", location);
 
 	if (contentType != "image/gif" || contentType != "image/jpeg"
@@ -1136,12 +1136,16 @@ Server::makeResponseBodyMessage(
 	Response response = Response();
 
 	if (statusCode == 301 || statusCode == 503)
-		response.setHttpResponseHeader("retry-after", 10);
-	if (300 <= statusCode < 400 || statusCode == 201)
+		response.setHttpResponseHeader("retry-after", "10");
+	if ((300 <= statusCode && statusCode < 400) || statusCode == 201)
 		response.setHttpResponseHeader("location", location);
 
-	if (method == "TRACE")
-		response.setHttpResponseHeader("connection", "close");
+	if (contentType != "image/gif" || contentType != "image/jpeg"
+	|| contentType != "image/png" || contentType != "image/x-icon")
+		response.setHttpResponseHeader("referer", referer);
+
+	if (method == "GET")
+		response.setHttpResponseHeader("last-modified", response.get_m_date());
 	else if (method == "POST")
 		response.setHttpResponseHeader("content-location", content_location);
 	else if (method == "PUT")
@@ -1197,7 +1201,7 @@ Server::parseErrorResponse(int clientfd)
 {
 	int status_code(this->m_requests[clientfd].get_m_error_code());
 	return (
-		Server::makeResponseBodyMessage(status_code, makeErrorPage(status_code))
+		Server::makeResponseBodyMessage(status_code, makeErrorPage(status_code), "")
 	);
 }
 
@@ -1206,9 +1210,9 @@ Server::checkValidRequestHeader(int clientfd)
 {
 	/* If request has no Host Header */
 	if (this->m_requests[clientfd].get_m_uri().get_m_host() == "")
-		return (Server::makeResponseBodyMessage(400, makeErrorPage(400)));
+		return (Server::makeResponseBodyMessage(400, makeErrorPage(400), ""));
 	return (
-		Server::makeResponseBodyMessage(400, makeErrorPage(400))
+		Server::makeResponseBodyMessage(400, makeErrorPage(400), "")
 	);
 }
 
@@ -1326,7 +1330,7 @@ Server::sendResponse(int clientfd)
 			response = this->methodOPTIONS(clientfd);
 			break;
 		default:
-			response = Server::makeResponseBodyMessage(405, makeErrorPage(405));
+			response = Server::makeResponseBodyMessage(405, makeErrorPage(405), "");
 			break;
 		}
 	}

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1213,7 +1213,9 @@ Server::parseErrorResponse(int clientfd)
 Response
 Server::checkValidRequestHeader(int clientfd)
 {
-	int status_code(this->m_requests[clientfd].get_m_error_code());
+	/* If request has no Host Header */
+	if (this->m_requests[clientfd].get_m_uri().get_m_host() == "")
+		return (Server::makeResponseBodyMessage(400, makeErrorPage(400)));
 	return (
 		Server::makeResponseBodyMessage(400, makeErrorPage(400))
 	);


### PR DESCRIPTION
### Header들이 추가됐습니다. 다음 사항들에 대한 로직이 추가됐습니다. (Header 추가 내용) (#130)

- Content-Location
  - Content-Location 헤더는 반환된 데이터에 대한 대체 위치을 가르킵니다. 주된 유스케이스는 컨텐츠 협상의 결과로써 전달되는 리소스의 URL을 가르키는 것입니다.
  - 실제로 HTTP RFC는 PUT 및 POST에 대한 Content-Location의 정의 된 동작이 없다고 말합니다.
- Host
  - Host 헤더의 필드는 모든 HTTP/1.1 요청 메시지 내에 포함되어 전송되어야 합니다.
  - __Host 헤더 필드가 없거나 한 개 이상의 필드를 포함하는 HTTP/1.1 요청 메시지에 대해서는 400 (Bad Request) 상태 코드가 전송될 것입니다.__
  - 그에 대한 로직은 request에서 처리했습니다.
- Retry-After
  - Retry-After 응답 HTTP 헤더는 다음에 올 요청이 이루어지기 전에 사용자 에이전트가 대기해야 하는 시간을 가르킵니다.  
  - 503 (Service Unavailable), 301 (Moved Permanently)
- Location
  -  Location응답 헤더에 페이지를 리디렉션 할 URL을 나타냅니다.
  - 3xx (리디렉션) 또는 201(생성 된) 상태 응답과 함께 제공 될 때만 의미를 제공합니다.
- Referer
  - Referer 요청 헤더는 현재 요청된 페이지의 링크 이전의 웹 페이지 주소를 포함합니다.
  - Referer 헤더는 다음과 같은 경우 브라우저에 의해 전송되지 않습니다:
    - 참조되는 리소스가 로컬 "파일" 혹은 "데이터"의 URI인 경우,
- User-Agent
  - 서버는 추가하지 않음으로 패스
- Transfer-Encoding
  - chuncked



```c++
Response
Server::makeResponseMessage(
	int statusCode, std::string path, std::string transfer_encoding, std::string method, std::string contentType,
	std::string referer,
	int dateHour, int dateMinute, int dateSecond, std::string allow_method, std::string content_location,
	std::string location,
	std::string contentLanguage, std::string server
)
{
	(void) transfer_encoding;
	Response response = Response();

	if (statusCode == 301 || statusCode == 503)
		response.setHttpResponseHeader("retry-after", "10");
	if ((300 <= statusCode && statusCode < 400) || statusCode == 201)
		response.setHttpResponseHeader("location", location);

	if (contentType != "image/gif" || contentType != "image/jpeg"
	|| contentType != "image/png" || contentType != "image/x-icon")
		response.setHttpResponseHeader("referer", referer);

	if (method == "GET")
		response.setHttpResponseHeader("last-modified", response.get_m_date());
	else if (method == "POST")
		response.setHttpResponseHeader("content-location", content_location);
	else if (method == "PUT")
		response.setHttpResponseHeader("content-location", content_location);
	else if (method == "OPTIONS")
		response.setHttpResponseHeader("allow", allow_method);

	return (
		response
			.setStatusCode(statusCode)
			.setCurrentDate(dateHour, dateMinute, dateSecond)
			.setPublicFileDocument(path)
			.setContentLanguage(contentLanguage)
			.setContentType(contentType)
			.setServer(server)
			.setHttpResponseHeader("date", response.get_m_date())
			.setHttpResponseHeader("content-length", std::to_string(response.get_m_content_length()))
			.setHttpResponseHeader("content-language", response.get_m_content_language())
			.setHttpResponseHeader("content-type", response.get_m_content_type())
			.setHttpResponseHeader("status", std::to_string(response.get_m_status_code()))
			.setHttpResponseHeader("server", response.get_m_server())
			.makeHttpResponseMessage(method)
	);
}
```

- makeResponseMessage나 makeResponseBodyMessage를 만들때 순서가 조금 바꼈습니다. 헤더를 참조해서 만들어주세요.