### PR TITLE
[FIX] add buffer to Request::getMessage()

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -76,7 +76,7 @@ class Request
 		std::string getContentLength();
 		std::string getContentType();
 		std::string getAcceptLanguage();
-		bool isBreakCondition(bool*, int, int);
+		bool isBreakCondition(bool*, int, int, std::string *);
 		bool getMessage(int);
 		bool parseMessage(bool);
 		bool parseRequestLine(std::string);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -435,14 +435,22 @@ Request::parseRequestLine(std::string request_line)
 bool
 Request::parseHeader(std::string line)
 {
-	std::vector<std::string> key_value = ft::split(line, ':');
+	std::vector<std::string> key_value;
 
+	size_t pos = line.find_first_of(":");
+
+	if (pos == std::string::npos)
+	{
+		this->m_error_code = 400;
+		return (false);
+	}
+	key_value.push_back(line.substr(0, pos));
+	key_value.push_back(line.substr(pos + 1, std::string::npos));
 	if (key_value.size() < 2)
 	{
 		this->m_error_code = 400;
 		return (false);
 	}
-
 	int key_len = key_value[0].length();
 	if (key_len == 0 || key_value[0][key_len - 1] == ' ')
 	{


### PR DESCRIPTION
메세지 받다가 남는 건 static std::string buff에 넣어둡니다. 
#222  에러도 수정했는데 referer헤더 한번만 확인부탁해요. @hochan222 