### PR TITLE
[FEAT] update methodGET

### DIFF
--- a/config/ftinx_jwon.conf
+++ b/config/ftinx_jwon.conf
@@ -15,8 +15,8 @@ http {
             cgi_path /Users/jwon/github_42cursus/15_webserv/ftinx/webserv/cgi-bin/cgi_tester
             index index.html
             root /Users/jwon/github_42cursus/15_webserv/ftinx/webserv/www
-            auth_basic jwon
-            auth_basic_user_file .htpasswd
+            # auth_basic jwon
+            # auth_basic_user_file .htpasswd
             autoindex on
         }
         location /put_test {
@@ -37,6 +37,10 @@ http {
             cgi .bla .php
             cgi_path /Users/jwon/github_42cursus/15_webserv/ftinx/webserv/YoupiBanane/youpi.bad_extension
             root /Users/jwon/github_42cursus/15_webserv/ftinx/webserv/YoupiBanane
+        }
+        location /head {
+            limit_except GET
+            index index.html
         }
     }
 #첫번째 서버블록 끝, 두번째 서버블록 시작

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -793,6 +793,8 @@ Server::methodGET(int clientfd, std::string method)
 	{
 		if (ft::isValidFilePath(absolute_path))
 		{
+			if (absolute_path.find("/.", absolute_path.find_last_of("/") - 1, 2) != std::string::npos)
+				return (Server::makeResponseBodyMessage(404, this->m_server_name, makeErrorPage(404), "", req.getAcceptLanguage(), method, getMimeType("html"), req.getReferer()));
 			extension = absolute_path.substr(absolute_path.find_last_of(".") + 1, std::string::npos);
 			// if (type.compare(0, 5, "image") == 0) //
 			// 	return (Server::makeResponseBodyMessage(200, this->m_server_name, std::string("data:image/png;base64,") + ft::encode(ft::fileToString(absolute_path)), req.getAcceptLanguage(), method, type, req.getReferer()));

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -648,9 +648,9 @@ Server::makeAutoindexPage(std::string root, std::string path)
 	}
 	page += std::string("</p><hr>\n<i>")
 			+ std::string(this->m_server_name)
-			+ std::string(" by ftinx 0.1 port ")
+			+ std::string(" (port ")
 			+ std::string(std::to_string(this->m_port))
-			+ std::string("</i>\n</body>\n</html>\n");
+			+ std::string(")</i>\n</body>\n</html>\n");
 	closedir(dirptr);
 	return (page);
 }
@@ -1285,9 +1285,9 @@ Server::makeErrorPage(int status_code)
 			+ std::string("</h3>\n<p>The server encountered an unexpected condition that prevented it from fulfilling the request.<br>\n")
 			+ std::string("We are sorry for the inconvenience.</p>\n<hr>\n<i>")
 			+ std::string(m_server_name)
-			+ std::string(" by ftinx 0.1 port ")
+			+ std::string(" (port ")
 			+ std::string(std::to_string(m_port))
-			+ std::string("</i>\n</center>\n</body>\n</html>\n");
+			+ std::string(")</i>\n</center>\n</body>\n</html>\n");
 	return (page);
 }
 


### PR DESCRIPTION
- severname 형식이 변경됨에 따라 #238
  makeAutoIndexPage, makeErrorPage 페이지에서 servername 출력하는 부분 수정

- .으로 시작하는 숨김파일과 폴더에 대한 get 요청관련 
  autoindex 에서는 숨김처리 하고 있음
  직접 주소를 알아내어 get 요청 시 404페이지로 응답