### PR TITLE
[FEAT] CGI logic added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CLEAR = \033[0m
 
 NAME = Webserv
 CC = clang++ -std=c++98
-# FLAGS = -Wall -Wextra -Werror -g3 -fsanitize=address
-FLAGS = -Wall -Wextra -Werror
+FLAGS = -Wall -Wextra -Werror -g3 -fsanitize=address
+# FLAGS = -Wall -Wextra -Werror
 
 DIR_HEADER =	./includes/
 DIR_SRC =		./srcs/

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -33,6 +33,7 @@ class Request
 		std::string m_path_translated;
 		std::string m_path_info;
 		std::string m_script_name;
+		pid_t m_cgi_pid;
 
 		/* HTTP Header */
 		std::string m_content_type;
@@ -59,6 +60,7 @@ class Request
 		std::string get_m_path_translated() const;
 		std::string get_m_path_info() const;
 		std::string get_m_script_name() const;
+		pid_t get_m_cgi_pid() const;
 		std::string get_m_content_type() const;
 		std::string get_m_referer() const;
 
@@ -67,6 +69,7 @@ class Request
 		void set_m_cgi_version(std::string);
 		void set_m_check_cgi(bool);
 		void set_m_method(Method);
+		void set_m_cgi_pid(pid_t);
 
 		// setHeaders
 		void set_m_body(std::string);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -107,6 +107,7 @@ class Server
 
 		/* Request */
 		void getRequest(fd_set *, fd_set *, fd_set *, fd_set *, int *);
+		int findMaxFd();
 		void acceptSocket();
 		void handleRequest(int);
 		bool readProcess();

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -18,7 +18,6 @@
 #include "HttpConfig.hpp"
 #include "HttpConfigLocation.hpp"
 #include "Utils.hpp"
-#include "signal.h"
 
 #define MAX_SOCK_NUM 1024
 #define MAXLINE 2048

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -61,10 +61,6 @@ class Server
 
 		std::vector<FDT> m_fd_table;
 
-		/* cgi fd */
-		int m_cgi_parent_write;
-		int m_cgi_parent_read;
-
 		/* Request, Response */
 		std::vector<Request> m_requests;
 		std::vector<Response> m_responses;

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -18,6 +18,7 @@
 #include "HttpConfig.hpp"
 #include "HttpConfigLocation.hpp"
 #include "Utils.hpp"
+#include "signal.h"
 
 #define MAX_SOCK_NUM 1024
 #define MAXLINE 2048

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -109,8 +109,8 @@ class Server
 		void getRequest(fd_set *, fd_set *, fd_set *, fd_set *, int *);
 		void acceptSocket();
 		void handleRequest(int);
-		void readProcess();
-		void writeProcess();
+		bool readProcess();
+		bool writeProcess();
 
 		/* Server Util */
 		std::vector<HttpConfigLocation> getMethodLocation(Method method);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -59,7 +59,7 @@ class Server
 		fd_set *m_write_fds;
 		fd_set *m_copy_write_fds;
 
-		std::vector< std::pair<FdType, int> > m_fd_table;
+		std::vector<FDT> m_fd_table;
 
 		/* cgi fd */
 		int m_cgi_parent_write;
@@ -139,7 +139,7 @@ class Server
 		std::map<std::string, std::string> makeCgiEnvpMap(Request req, Response res);
 		char** makeCgiEnvp(Request req, Response res);
 		char** makeCgiArgv(Request req);
-		Response executeCgi(Request req, Response res, std::string method);
+		Response executeCgi(Request req, Response res, int clientfd);
 		static std::map<std::string, std::string> parseQuery(std::string str);
 		static Response postAuth(Request req, Response res);
 		Response methodPOST(int clientfd, std::string method="POST");

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include <signal.h>
+
 #include "Server.hpp"
 #include "HttpConfig.hpp"
 
@@ -50,7 +52,7 @@ class ServerManager
 		);
 		void initServers();
 		void runServers();
-		void exitServers();
+		void exitServers(int signo);
 };
 
 #endif

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -96,7 +96,6 @@ namespace ft
 	bool checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list);
 	std::string getErrorMessage(int status_code);
 	FDT *makeFDT(enum FdType type, int sockfd, int clientfd);
-
 	std::string encode(const std::string &input);
 	std::string decode(const std::string &input);
 

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -95,7 +95,7 @@ namespace ft
 	bool checkValidFileExtension(std::string file_name, std::string ext);
 	bool checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list);
 	std::string getErrorMessage(int status_code);
-	FDT *makeFDT(enum FdType type, int sockfd, int clientfd);
+	FDT makeFDT(enum FdType type, int sockfd, int clientfd);
 	std::string encode(const std::string &input);
 	std::string decode(const std::string &input);
 

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -95,7 +95,7 @@ namespace ft
 	bool checkValidFileExtension(std::string file_name, std::string ext);
 	bool checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list);
 	std::string getErrorMessage(int status_code);
-	FDT makeFDT(enum FdType type, int sockfd, int clientfd);
+	FDT *makeFDT(enum FdType type, int sockfd, int clientfd);
 
 	std::string encode(const std::string &input);
 	std::string decode(const std::string &input);

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -36,6 +36,14 @@ enum FdType
     CLOSED,
 };
 
+struct FDT
+{
+	enum FdType type;
+	int sockfd;
+	int clientfd;
+};
+
+
 namespace ft
 {
 	/* LIBFT C */
@@ -87,6 +95,7 @@ namespace ft
 	bool checkValidFileExtension(std::string file_name, std::string ext);
 	bool checkValidFileExtension(std::string file_name, std::vector<std::string> ext_list);
 	std::string getErrorMessage(int status_code);
+	FDT makeFDT(enum FdType type, int sockfd, int clientfd);
 
 	std::string encode(const std::string &input);
 	std::string decode(const std::string &input);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -409,7 +409,7 @@ Request::getMessage(int fd)
 			break;
 		memset(recvline, 0, MAXLINE);
 	}
-	if (ret < 0)
+	if (ret <= 0)
 	{
 		close(fd);
 		return (false);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -417,7 +417,10 @@ Request::getMessage(int fd)
 	// std::cout << "\033[43;31m**** request message *****\033[0m" << std::endl;
 	// std::cout << m_message << std::endl;
 	if (this->parseMessage(chunked) == false)
+	{
+		close(fd);
 		return (false);
+	}
 	return (true);
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -10,7 +10,7 @@ Request::Request()
 : m_message(""), m_http_version(""), m_cgi_version(""), m_check_cgi(false),
 m_method(DEFAULT), m_uri(), m_headers(), m_body(""), m_error_code(0),
 m_reset_path(""), m_location_block(),
-m_path_translated(""), m_path_info(""), m_script_name(""),
+m_path_translated(""), m_path_info(""), m_script_name(""), m_cgi_pid(),
 m_content_type(""), m_referer("")
 {
 }
@@ -38,6 +38,7 @@ Request& Request::operator=(Request const &rhs)
 	this->m_path_translated = rhs.get_m_path_translated();
 	this->m_path_info = rhs.get_m_path_info();
 	this->m_script_name = rhs.get_m_script_name();
+	this->m_cgi_pid = rhs.get_m_cgi_pid();
 	this->m_content_type = rhs.get_m_content_type();
 	this->m_referer = rhs.get_m_referer();
 	return (*this);
@@ -142,6 +143,12 @@ Request::get_m_script_name() const
 	return (this->m_script_name);
 }
 
+pid_t
+Request::get_m_cgi_pid() const
+{
+	return (this->m_cgi_pid);
+}
+
 std::string
 Request::get_m_content_type() const
 {
@@ -204,6 +211,12 @@ void
 Request::set_m_location_block(HttpConfigLocation block)
 {
 	this->m_location_block = block;
+}
+
+void
+Request::set_m_cgi_pid(pid_t pid)
+{
+	this->m_cgi_pid = pid;
 }
 
 /*============================================================================*/

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -999,11 +999,14 @@ Server::executeCgi(Request req, Response res, int clientfd)
 		ft::doubleFree(argv);
 		ft::doubleFree(envp);
 		std::cout << "PARENT WRITE FD " << parent_write << std::endl;
+		std::cout << "PARENT READ FD " << parent_read << std::endl;
 		m_fd_table.push_back(*ft::makeFDT(CGI_PIPE, parent_write, clientfd));
 		m_fd_table.push_back(*ft::makeFDT(CGI_PIPE, parent_read, clientfd));
 		ft::fdSet(parent_write, m_write_fds);
 		ft::fdSet(parent_read, m_main_fds);
-		*m_maxfd += 2;
+		*m_maxfd = std::max(*m_maxfd, parent_write);
+		*m_maxfd = std::max(*m_maxfd, parent_read);
+		std::cout << "MAX FD: " << *m_maxfd << std::endl;
 	}
 	(void)clientfd;
 	return (response);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -295,7 +295,7 @@ Server::acceptSocket()
 		std::cerr << "accept error" << std::endl;
 		return ;
 	}
-	m_fd_table.push_back(*ft::makeFDT(C_SOCKET, this->m_client_socket, 0));
+	m_fd_table.push_back(ft::makeFDT(C_SOCKET, this->m_client_socket, 0));
 	ft::fdSet(this->m_client_socket, this->m_main_fds);
 	if (this->m_client_socket > *this->m_maxfd)
 		*(this->m_maxfd) = this->m_client_socket;
@@ -1018,8 +1018,8 @@ Server::executeCgi(Request req, Response res, int clientfd)
 		ft::doubleFree(envp);
 		std::cout << "PARENT WRITE FD " << parent_write << std::endl;
 		std::cout << "PARENT READ FD " << parent_read << std::endl;
-		m_fd_table.push_back(*ft::makeFDT(CGI_PIPE, parent_write, clientfd));
-		m_fd_table.push_back(*ft::makeFDT(CGI_PIPE, parent_read, clientfd));
+		m_fd_table.push_back(ft::makeFDT(CGI_PIPE, parent_write, clientfd));
+		m_fd_table.push_back(ft::makeFDT(CGI_PIPE, parent_read, clientfd));
 		ft::fdSet(parent_write, m_write_fds);
 		ft::fdSet(parent_read, m_main_fds);
 		// *m_maxfd = std::max(*m_maxfd, parent_write);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -339,7 +339,7 @@ Server::handleRequest(int clientfd)
 }
 
 
-void
+bool
 Server::readProcess()
 {
 	std::vector<FDT>::const_iterator fd_iter;
@@ -371,7 +371,7 @@ Server::readProcess()
 					ft::fdClr(fd_iter->sockfd, m_main_fds);
 					ft::fdSet(fd_iter->clientfd, m_write_fds);
 					this->m_fd_table.erase(fd_iter);
-					return;
+					return (true);
 				}
 			}
 			else if(fd_iter->type == C_SOCKET)
@@ -382,18 +382,18 @@ Server::readProcess()
 				{
 					ft::fdClr(this->m_sockfd, this->m_main_fds);
 					if (this->m_fd_table.size() <= 0)
-						break;
+						return (false);
 				}
 				resetRequest(&this->m_requests[sockfd]);
 				handleRequest(sockfd);
-				return;
+				return (true);
 			}
 		}
 	}
-	return ;
+	return (false);
 }
 
-void
+bool
 Server::writeProcess()
 {
 	std::vector<FDT>::const_iterator fd_iter;
@@ -418,7 +418,7 @@ Server::writeProcess()
 				ft::fdClr(sockfd, this->m_write_fds);
 				this->m_fd_table.erase(fd_iter);
 				*m_maxfd -= 1;
-				return;
+				return (true);
 			}
 			else if(fd_iter->type == C_SOCKET)
 			{
@@ -430,11 +430,11 @@ Server::writeProcess()
 					*m_maxfd -= 1;
 					//this->m_fd_table.erase(fd_iter);
 				}
-				return;
+				return (true);
 			}
 		}
 	}
-	return ;
+	return (false);
 }
 
 void
@@ -447,7 +447,8 @@ Server::getRequest(fd_set *main_fds, fd_set *read_fds, fd_set *copy_write_fds, f
 	this->m_write_fds = write_fds;
 	this->m_maxfd = maxfd;
 
-	writeProcess();
+	if (writeProcess() == true)
+		return;
 	if (ft::fdIsSet(this->m_server_socket, this->m_read_fds))
 	{
 		acceptSocket();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1419,15 +1419,17 @@ Server::sendResponse(int clientfd)
 	// std::cout << response.get_m_reponse_message() << std::endl;
 
 	/* 아무것도 전송안할순없으니까 0도 포함..? */
-	if (send(clientfd, m_responses[clientfd].get_m_reponse_message().c_str(), m_responses[clientfd].get_m_response_size(), 0) < 0)
+	int ret;
+
+	if ((ret = send(clientfd, m_responses[clientfd].get_m_reponse_message().c_str(), m_responses[clientfd].get_m_response_size(), 0)) < 0)
 	{
 		std::cout << "XXXXXXX" << std::endl;
 		close(clientfd);
 		return (false);
 	}
-	else if (send(clientfd, m_responses[clientfd].get_m_reponse_message().c_str(), m_responses[clientfd].get_m_response_size(), 0) == 0)
+	else if (ret == 0)
 	{
-		std::cout << "OOOO" << std::endl;
+		std::cout << "OOOOOOO" << std::endl;
 	}
 	writeLog("response", m_responses[clientfd]);
 	return (true);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -398,11 +398,10 @@ Server::readProcess()
 				if (this->m_requests[sockfd].getMessage(sockfd) == false)
 				{
 					ft::fdClr(sockfd, this->m_main_fds);
-					// close(sockfd);
-					// this->m_fd_table.erase(fd_iter);
-					// *m_maxfd = findMaxFd();
-					// if (this->m_fd_table.size() <= 0)
-					// 	return (false);
+					this->m_fd_table.erase(fd_iter);
+					*m_maxfd = findMaxFd();
+					if (this->m_fd_table.size() <= 0)
+						return (false);
 					return (false);
 				}
 				resetRequest(&this->m_requests[sockfd]);
@@ -461,7 +460,6 @@ Server::writeProcess()
 void
 Server::getRequest(fd_set *main_fds, fd_set *read_fds, fd_set *copy_write_fds, fd_set *write_fds, int *maxfd)
 {
-	(void)copy_write_fds;
 	this->m_main_fds = main_fds;
 	this->m_read_fds = read_fds;
 	this->m_copy_write_fds = copy_write_fds;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -384,6 +384,7 @@ Server::readProcess()
 						body += std::string(buff);
 					}
 					this->m_responses[fd_iter->clientfd] = Server::makeResponseBodyMessage(200, this->m_server_name, body);
+					std::cout << "PARENT READ FD: " << fd_iter->sockfd << std::endl;
 					ft::fdClr(fd_iter->sockfd, m_main_fds);
 					ft::fdSet(fd_iter->clientfd, m_write_fds);
 					this->m_fd_table.erase(fd_iter);
@@ -393,15 +394,17 @@ Server::readProcess()
 			}
 			else if(fd_iter->type == C_SOCKET)
 			{
-				std::cout << "::1::"<<std::endl;
+				std::cout << "::1:: " << sockfd << " ::" <<std::endl;
 				this->m_requests[sockfd] = Request();
 				if (this->m_requests[sockfd].getMessage(sockfd) == false)
 				{
-					ft::fdClr(sockfd, this->m_main_fds);
-					this->m_fd_table.erase(fd_iter);
-					*m_maxfd = findMaxFd();
-					if (this->m_fd_table.size() <= 0)
-						return (false);
+					// std::cout << "XXXXXXX" << std::endl;
+					// ft::fdClr(sockfd, this->m_main_fds);
+					// this->m_fd_table.erase(fd_iter);
+					// *m_maxfd = findMaxFd();
+					// if (this->m_fd_table.size() <= 0)
+					// 	return (false);
+					return (false);
 				}
 				resetRequest(&this->m_requests[sockfd]);
 				handleRequest(sockfd);
@@ -443,8 +446,6 @@ Server::writeProcess()
 				if (sendResponse(sockfd) == true)
 				{
 					ft::fdClr(sockfd, this->m_write_fds);
-					// this->m_fd_table.erase(fd_iter);
-					// *m_maxfd = findMaxFd();
 					return (true);
 				}
 			}
@@ -616,7 +617,7 @@ Server::writeLog(std::string type, Response response)
 		ft::putstr_fd("] [ ", fd);
 		ft::putstr_fd(ft::getDateTimestamp(0, 0, 0).c_str(), fd);
 		ft::putendl_fd(" ] ----------", fd);
-		//ft::putendl_fd(this->m_requests[this->m_sockfd].get_m_message().c_str(), fd);
+		// ft::putendl_fd(this->m_requests[this->m_sockfd].get_m_message().c_str(), fd);
 		ft::putendl_fd("---------------------------------------------------------------------------",fd);
 	}
 	else if (type.compare("response") == 0)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -421,11 +421,9 @@ Server::writeProcess()
 
 	for (fd_iter = m_fd_table.begin() ; fd_iter != m_fd_table.end() ; ++fd_iter)
 	{
-		// std::cout << fd_iter->first << std::endl;
 		int sockfd = fd_iter->sockfd;
 		if (ft::fdIsSet(sockfd, this->m_copy_write_fds))
 		{
-			/* good code */
 			if (fd_iter->type == CGI_PIPE)
 			{
 				std::cout << "::2::"<<std::endl;
@@ -993,23 +991,6 @@ Server::executeCgi(Request req, Response res, int clientfd)
 	}
 	else  // parent process
 	{
-		/* bad code */
-		// close(cgi_stdout);
-		// close(cgi_stdin);
-		// ft::doubleFree(argv);
-		// ft::doubleFree(envp);
-		// std::cout << "PARENT WRITE FD " << parent_write << std::endl;
-		// m_fd_table.push_back(*ft::makeFDT(CGI_PIPE, parent_read, clientfd));
-		// ft::fdSet(parent_read, m_main_fds);
-		// *m_maxfd += 1;
-
-		// std::cout << "::2::"<<std::endl;
-		// std::string body = req.get_m_body();
-		// char *buff = (char *)body.c_str();
-		// write(parent_write, buff, body.size());
-		// close(parent_write);
-
-		/* good code */
 		close(cgi_stdout);
 		close(cgi_stdin);
 		ft::doubleFree(argv);
@@ -1020,8 +1001,6 @@ Server::executeCgi(Request req, Response res, int clientfd)
 		m_fd_table.push_back(ft::makeFDT(CGI_PIPE, parent_read, clientfd));
 		ft::fdSet(parent_write, m_write_fds);
 		ft::fdSet(parent_read, m_main_fds);
-		// *m_maxfd = std::max(*m_maxfd, parent_write);
-		// *m_maxfd = std::max(*m_maxfd, parent_read);
 		*m_maxfd = findMaxFd();
 		std::cout << "MAX FD: " << *m_maxfd << std::endl;
 	}

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -346,7 +346,6 @@ Server::handleRequest(int clientfd)
 	{
 		std::cout << "STATUS CODE: " << this->m_responses[clientfd].get_m_status_code();
 		ft::fdSet(clientfd, m_write_fds);
-		*m_maxfd = findMaxFd();
 	}
 	return ;
 }
@@ -398,8 +397,8 @@ Server::readProcess()
 				this->m_requests[sockfd] = Request();
 				if (this->m_requests[sockfd].getMessage(sockfd) == false)
 				{
-					// std::cout << "XXXXXXX" << std::endl;
-					// ft::fdClr(sockfd, this->m_main_fds);
+					ft::fdClr(sockfd, this->m_main_fds);
+					// close(sockfd);
 					// this->m_fd_table.erase(fd_iter);
 					// *m_maxfd = findMaxFd();
 					// if (this->m_fd_table.size() <= 0)
@@ -434,8 +433,8 @@ Server::writeProcess()
 				std::string body = this->m_requests[fd_iter->clientfd].get_m_body();
 				char *buff = (char *)body.c_str();
 				write(sockfd, buff, body.size());
-				close(sockfd);
 				ft::fdClr(sockfd, this->m_write_fds);
+				close(sockfd);
 				this->m_fd_table.erase(fd_iter);
 				*m_maxfd = findMaxFd();
 				return (true);
@@ -446,6 +445,10 @@ Server::writeProcess()
 				if (sendResponse(sockfd) == true)
 				{
 					ft::fdClr(sockfd, this->m_write_fds);
+					ft::fdClr(sockfd, this->m_main_fds);
+					// this->m_fd_table.erase(fd_iter);
+					// *m_maxfd = findMaxFd();
+					// close(sockfd);
 					return (true);
 				}
 			}

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -296,7 +296,6 @@ Server::acceptSocket()
 		return ;
 	}
 	m_fd_table.push_back(*ft::makeFDT(C_SOCKET, this->m_client_socket, 0));
-
 	ft::fdSet(this->m_client_socket, this->m_main_fds);
 	if (this->m_client_socket > *this->m_maxfd)
 		*(this->m_maxfd) = this->m_client_socket;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -333,6 +333,7 @@ Server::handleRequest(int clientfd)
 	}
 	if (this->m_responses[clientfd].get_m_status_code() != 0)
 	{
+		std::cout << "STATUS CODE: " << this->m_responses[clientfd].get_m_status_code() ;
 		ft::fdSet(clientfd, m_write_fds);
 	}
 	return ;
@@ -366,6 +367,8 @@ Server::readProcess()
 						buff[ret] = '\0';
 						printf("%s\n", buff);
 					}
+					ft::fdClr(fd_iter->sockfd, m_main_fds);
+					this->m_fd_table.erase(fd_iter);
 					ft::fdSet(fd_iter->clientfd, m_write_fds);
 				}
 			}
@@ -375,8 +378,7 @@ Server::readProcess()
 				this->m_requests[sockfd] = Request();
 				if (this->m_requests[sockfd].getMessage(sockfd) == false)
 				{
-					ft::fdClr(sockfd, this->m_main_fds);
-					this->m_fd_table.erase(fd_iter);
+					ft::fdClr(this->m_sockfd, this->m_main_fds);
 					if (this->m_fd_table.size() <= 0)
 						break;
 				}
@@ -418,10 +420,10 @@ Server::writeProcess()
 				std::cout << "::4::"<<std::endl;
 				if (sendResponse(sockfd) == true)
 				{
+					std::cout << "ERASE " <<sockfd << " FD" << std::endl;
 					ft::fdClr(sockfd, this->m_write_fds);
-					this->m_fd_table.erase(fd_iter);
+					//this->m_fd_table.erase(fd_iter);
 				}
-				// FD_CLR(this->sockfd, main_fds);
 			}
 		}
 	}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -152,6 +152,10 @@ ServerManager::runServers()
 		// printf("---Select Wait %d---\n", this->m_maxfd);
 		this->m_read_fds = this->m_main_fds;
 		this->m_copy_write_fds = this->m_write_fds;
+		for (int i=0; i<1; i++) {
+			std::cout << "-----" << "BEFORE SELECT" << "-----" << std::endl;
+			std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl;
+		}
 
 		fd_num = select(
 			this->m_maxfd + 1 ,
@@ -160,6 +164,10 @@ ServerManager::runServers()
 			reinterpret_cast<fd_set *>(0),
 			&timeout
 		);
+		for (int i=0; i<1; i++) {
+			std::cout << "-----" << "AFTER SELECT" << "-----" << std::endl;
+			std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl << std::endl;;
+		}
 
 		switch (fd_num)
 		{

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -137,6 +137,8 @@ ServerManager::runServers()
 	timeout.tv_sec = 1;
 	timeout.tv_usec = 2;
 
+	signal(SIGPIPE, SIG_IGN);
+
 	this->m_maxfd = 0;
 	FD_ZERO(&this->m_main_fds);
 	FD_ZERO(&this->m_write_fds);
@@ -192,7 +194,12 @@ ServerManager::runServers()
 }
 
 void
-ServerManager::exitServers()
+ServerManager::exitServers(int signo)
 {
+	if (signo == SIGINT)
+	{
+		/* clean heap */
+		exit(EXIT_SUCCESS);
+	}
 	return ;
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -134,7 +134,7 @@ ServerManager::runServers()
 	int fd_num = 0;
 
 	struct timeval timeout;
-	timeout.tv_sec = 4;
+	timeout.tv_sec = 1;
 	timeout.tv_usec = 2;
 
 	this->m_maxfd = 0;

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -152,10 +152,10 @@ ServerManager::runServers()
 		// printf("---Select Wait %d---\n", this->m_maxfd);
 		this->m_read_fds = this->m_main_fds;
 		this->m_copy_write_fds = this->m_write_fds;
-		for (int i=0; i<1; i++) {
-			std::cout << "-----" << "BEFORE SELECT" << "-----" << std::endl;
-			std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl;
-		}
+		// for (int i=0; i<1; i++) {
+		// 	std::cout << "-----" << "BEFORE SELECT" << "-----" << std::endl;
+		// 	std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl;
+		// }
 
 		fd_num = select(
 			this->m_maxfd + 1 ,
@@ -164,10 +164,10 @@ ServerManager::runServers()
 			reinterpret_cast<fd_set *>(0),
 			&timeout
 		);
-		for (int i=0; i<1; i++) {
-			std::cout << "-----" << "AFTER SELECT" << "-----" << std::endl;
-			std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl << std::endl;;
-		}
+		// for (int i=0; i<1; i++) {
+		// 	std::cout << "-----" << "AFTER SELECT" << "-----" << std::endl;
+		// 	std::cout << std::bitset<32>(this->m_copy_write_fds.fds_bits[i]) << std::endl << std::endl;;
+		// }
 
 		switch (fd_num)
 		{

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -620,6 +620,15 @@ isValidCharacter(char c)
 	return (std::isalnum(c) || (c == '+') || (c == '/'));
 }
 
+FDT
+makeFDT(enum FdType type, int sockfd, int clientfd)
+{
+	FDT fdt = {type, sockfd, clientfd};
+
+	return (fdt);
+}
+
+
 std::string
 encode(const std::string &input)
 {

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -620,15 +620,10 @@ isValidCharacter(char c)
 	return (std::isalnum(c) || (c == '+') || (c == '/'));
 }
 
-FDT*
+FDT
 makeFDT(enum FdType type, int sockfd, int clientfd)
 {
-	FDT *fdt = new FDT;
-
-	fdt->type = type;
-	fdt->sockfd = sockfd;
-	fdt->clientfd = clientfd;
-
+	FDT fdt = {type, sockfd, clientfd};
 	return (fdt);
 }
 

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -620,10 +620,14 @@ isValidCharacter(char c)
 	return (std::isalnum(c) || (c == '+') || (c == '/'));
 }
 
-FDT
+FDT*
 makeFDT(enum FdType type, int sockfd, int clientfd)
 {
-	FDT fdt = {type, sockfd, clientfd};
+	FDT *fdt = new FDT;
+
+	fdt->type = type;
+	fdt->sockfd = sockfd;
+	fdt->clientfd = clientfd;
 
 	return (fdt);
 }

--- a/www/script.js
+++ b/www/script.js
@@ -61,10 +61,12 @@ function getResponse(element_id, method, path, headers) {
 		});
 		res_headers += "\r\n\r\n"
 		document.getElementById(element_id).innerText += res_headers;
+		console.log(res_headers);
 		return res.text()
 	}
 
 	function getBody(data) {
+		console.log(data);
 		document.getElementById(element_id).innerText += data;
 	}
 }


### PR DESCRIPTION
### 자잘한 변수 수정
- Request에 m_cgi_pid 변수 추가 : executeCgi()에서 자식프로세스 pid 입니다
- Server에 불필요한 변수(m_cgi_parent_write, m_cgi_parent_read)삭제
- Server readProcess, writeProcess 를 bool로 바꿔 한번의 select에선 read/accept/write 로직 중 한가지만 진입하도록
- Server m_fd_table의 자료형 Utils의 FDT로 변경: cgi fd일때 원 clientfd를 저장할 필요가 있기 때문
- Request::getMessage에서 read 반환값이 0이면 상대방이 소켓을 끊은 것이므로 close

### 구조 수정
- readProcess, writeProcess에서 각각 cgi 관련 fd 를 처리하는 부분이 생겼습니다. 이번 PR의 주된 변화입니다. 

### 에러 수정 사항
- m_maxfd를 업데이트를 잘못해줘서 **cgi 요청을 제대로 처리하지 못하는 문제** 발생
- Server::findMaxFd함수 도입해 해결
- Server::findMaxFD: m_fd_table에 fd를 추가하거나 삭제한 뒤 m_maxfd를 업데이트하는 목적. 꼭 추가나 삭제 작업을 먼저 완료한 뒤에 사용하세요.

- **요청을 한 번 받고 두번 이상은 받지 못하는 문제** 발생
- 메세지를 모두 보내고 나면 해당 fd를 m_main_fd에서 없애줍니다. 요청이 오면 다시 켜질 거예요. m_fd_table에서 없애지 않는 까닭은 요청이 다시 오면 켜지기 때문에 때문에…
- m_fd_table에서 삭제하는 경우는 fd를 닫아버릴 때입니다. 1) cgi 프로세스에 바디를 모두 보냈을 때 cgi parent_write삭제 2) cgi 프로세스에서 리스폰스를 모두 받았을 때 cgi_parent_read 삭제 3) 클라이언트 소켓의 연결이 끊어져서 close 한 이후(getMessage의 반환값이 false일 때 입니다)
- 이 외의 경우가 있다면 얘기해주세요.  
