### PR TITLE
[FIX] default cgi

### DIFF
--- a/config/ftinx_holee.conf
+++ b/config/ftinx_holee.conf
@@ -15,8 +15,8 @@ http {
             cgi_path /Users/holee/Desktop/webserv/cgi-bin/cgi_tester
             index index.html
             root /Users/holee/Desktop/webserv/www
-            auth_basic jwon holee
-            auth_basic_user_file .htpasswd
+            # auth_basic jwon holee
+            # auth_basic_user_file .htpasswd
             autoindex on
         }
         location /put_test {
@@ -35,7 +35,7 @@ http {
             limit_except GET POST
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path /Users/holee/Desktop/webserv/cgi-bin/YoupiBanane/youpi.bad_extension
+            cgi_path /Users/holee/Desktop/webserv/YoupiBanane/youpi.bad_extension
             root /Users/holee/Desktop/webserv/YoupiBanane
         }
         location /head {

--- a/config/ftinx_tonybyeon.conf
+++ b/config/ftinx_tonybyeon.conf
@@ -35,7 +35,7 @@ http {
             limit_except GET POST
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/YoupiBanane/youpi.bad_extension
+            cgi_path /Users/tonybyeon/Desktop/webserv/YoupiBanane/youpi.bad_extension
             root /Users/tonybyeon/Desktop/webserv/YoupiBanane
         }
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -408,6 +408,7 @@ Server::readProcess()
 						}
 					}
 					std::cout << "READ PROCESS) BODY SIZE: " << this->m_responses[fd_iter->clientfd].get_m_cgi_response().size() << std::endl;
+					std::cout << "WHY: " << ":" << this->m_responses[fd_iter->clientfd].get_m_cgi_response() << ":"<< std::endl;
 					if (ret  == 0)
 					{
 						std::cout << "RET IS 0" << std::endl;
@@ -1130,7 +1131,7 @@ Server::executeCgi(Request req, Response res, int clientfd)
 	fcntl(parent_read, F_SETFL, O_NONBLOCK);
 	fcntl(parent_write, F_SETFL, O_NONBLOCK);
 
-	std::cout << "Execute Cgi >0<" << std::endl;
+	std::cout << "Execute Cgi >0<"<< req.get_m_path_translated().c_str() << std::endl;
 	pid = fork();
 
 	if (pid == 0) // child process


### PR DESCRIPTION
[FIX] default cgi

error 원인 

1. config file default cgi 경로가 잘못됐습니다. 그 위치에 cgi-tester가 없었습니다.
2. cgi-tester의 권한 바꿔야합니다.