### PR TITLE
[FEAT] update utils func parameter to ref

### DIFF
--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -62,12 +62,12 @@ namespace ft
 
 	/* LIBFT C++ */
 	int stoi(const std::string &str);
-	char* strdup(std::string str);
-	std::string ltrim(std::string str, std::string set);
-	std::string rtrim(std::string str, std::string set);
-	std::string trim(std::string str, std::string set);
-	std::vector<std::string> split(std::string const &str, char set);
-	std::vector<std::string> split(std::string const &str, std::string set);
+	char* strdup(const std::string &str);
+	std::string ltrim(const std::string &str, const std::string &set);
+	std::string rtrim(const std::string &str, const std::string &set);
+	std::string trim(const std::string &str, const std::string &set);
+	std::vector<std::string> split(const std::string &str, const char &set);
+	std::vector<std::string> split(const std::string &str, const std::string &set);
 
 	/* FD SET */
 	void fdZero(fd_set *fds);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1564,7 +1564,7 @@ Server::parseErrorResponse(int clientfd)
 		it = m_http_config_path_method.find(this->m_requests[clientfd].get_m_uri().get_m_path());
 		if (it != m_http_config_path_method.end())
 			allow_method = it->second;
-		return (Server::makeResponseBodyMessage(status_code, this->m_server_name, makeErrorPage(status_code), "", this->m_requests[clientfd].getAcceptLanguage(), "GET", getMimeType("html"), this->m_requests[clientfd].getReferer(), 0, 0, 0, allow_method));
+		return (Server::makeResponseMessage(status_code, this->m_server_name, makeErrorPage(status_code), "", this->m_requests[clientfd].getAcceptLanguage(), "GET", getMimeType("html"), this->m_requests[clientfd].getReferer(), 0, 0, 0, allow_method));
 	}
 	return (
 		Server::makeResponseBodyMessage(status_code, this->m_server_name, makeErrorPage(status_code), "", this->m_requests[clientfd].getAcceptLanguage(), "GET", getMimeType("html"), this->m_requests[clientfd].getReferer())

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -160,7 +160,7 @@ stoi(const std::string &str)
 }
 
 char *
-strdup(std::string str)
+strdup(const std::string &str)
 {
 	size_t	idx;
 	char	*ret;
@@ -178,7 +178,7 @@ strdup(std::string str)
 }
 
 std::string
-ltrim(std::string str, std::string set)
+ltrim(const std::string &str, const std::string &set)
 {
 	size_t n;
 
@@ -190,7 +190,7 @@ ltrim(std::string str, std::string set)
 }
 
 std::string
-rtrim(std::string str, std::string set)
+rtrim(const std::string &str, const std::string &set)
 {
 	size_t n;
 
@@ -202,13 +202,13 @@ rtrim(std::string str, std::string set)
 }
 
 std::string
-trim(std::string str, std::string set)
+trim(const std::string &str, const std::string &set)
 {
 	return (rtrim(ltrim(str, set), set));
 }
 
 std::vector<std::string>
-split(std::string const &str, char set)
+split(const std::string &str, const char &set)
 {
 	std::size_t start = 0;
 	std::size_t pos_set = 0;
@@ -228,7 +228,7 @@ split(std::string const &str, char set)
 }
 
 std::vector<std::string>
-split(std::string const &str, std::string set)
+split(const std::string &str, const std::string &set)
 {
 	std::size_t start = 0;
 	std::size_t pos_set = 0;


### PR DESCRIPTION
- 유틸함수 수정

```c++
char* strdup(const std::string &str);
std::string ltrim(const std::string &str, const std::string &set);
std::string rtrim(const std::string &str, const std::string &set);
std::string trim(const std::string &str, const std::string &set);
std::vector<std::string> split(const std::string &str, const char &set);
std::vector<std::string> split(const std::string &str, const std::string &set);
```

- 405 메소드에서 body보내지 않도록 수정 -> 이게 맞는지는 모르겠음