### PR TITLE
[REFACTOR] HttpConfig* parse

### DIFF
--- a/config/ftinx_holee.conf
+++ b/config/ftinx_holee.conf
@@ -1,6 +1,6 @@
 http {
-    software_name ftinx #프로그램명
-    software_version 0.1 #버전
+    software_name ftinx
+    software_version 0.1
     include mime.types
     default_type application/octet-stream
     root /Users/holee/Desktop/webserv/www

--- a/config/ftinx_jwon.conf
+++ b/config/ftinx_jwon.conf
@@ -1,6 +1,6 @@
 http {
-    software_name ftinx #프로그램명
-    software_version 0.1 #버전
+    software_name ftinx
+    software_version 0.1
     include mime.types
     default_type application/octet-stream
     root /Users/jwon/github_42cursus/15_webserv/ftinx/webserv/www

--- a/config/ftinx_jwon_cluster.conf
+++ b/config/ftinx_jwon_cluster.conf
@@ -1,10 +1,9 @@
 http {
-    software_name ftinx #프로그램명
-    software_version 0.1 #버전
+    software_name ftinx
+    software_version 0.1
     include mime.types
     default_type application/octet-stream
-    root /Users/jwon/42/webserv/www
-#서버블록 시작
+    root /Users/jwon/42/webserv_2/www
     server {
         server_name first_server
         listen 8080
@@ -13,34 +12,33 @@ http {
         location / {
             limit_except GET
             cgi .bin .cgi .bla
-            cgi_path /Users/jwon/42/webserv/cgi-bin/cgi_tester
+            cgi_path /Users/jwon/42/webserv_2/cgi-bin/cgi_tester
             index index.html
-            root /Users/jwon/42/webserv/www
-            # auth_basic jwon
-            # auth_basic_user_file .htpasswd
+            root /Users/jwon/42/webserv_2/www
+            auth_basic jwon
+            auth_basic_user_file .htpasswd
             autoindex on
         }
         location /put_test {
             limit_except PUT
-            root /Users/jwon/42/webserv/tests/put_test
+            root /Users/jwon/42/webserv_2/tests/put_test
             cgi .bla
-            cgi_path /Users/jwon/42/webserv/cgi-bin/cgi_tester
+            cgi_path /Users/jwon/42/webserv_2/cgi-bin/cgi_tester
         }
         location /post_body {
             limit_body_size 100
             limit_except POST
             index index.html
-            # root /Users/jwon/42/webserv/tests/folder
+            # root /Users/jwon/42/webserv_2/tests/folder
         }
         location /directory {
             limit_except GET POST
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path /Users/jwon/42/webserv/YoupiBanane/youpi.bla
-            root /Users/jwon/42/webserv/YoupiBanane
+            cgi_path /Users/jwon/42/webserv_2/YoupiBanane/youpi.bla
+            root /Users/jwon/42/webserv_2/YoupiBanane
         }
     }
-#첫번째 서버블록 끝, 두번째 서버블록 시작
     server {
         server_name second_server
         listen       8081
@@ -57,5 +55,4 @@ http {
             index index.html index.htm index.abc
         }
     }
-#서버블록 끝
 }

--- a/config/ftinx_jwon_cluster.conf
+++ b/config/ftinx_jwon_cluster.conf
@@ -3,7 +3,7 @@ http {
     software_version 0.1
     include mime.types
     default_type application/octet-stream
-    root /Users/jwon/42/webserv_2/www
+    root /Users/jwon/42/webserv/www
     server {
         server_name first_server
         listen 8080
@@ -12,31 +12,31 @@ http {
         location / {
             limit_except GET
             cgi .bin .cgi .bla
-            cgi_path /Users/jwon/42/webserv_2/cgi-bin/cgi_tester
+            cgi_path /Users/jwon/42/webserv/cgi-bin/cgi_tester
             index index.html
-            root /Users/jwon/42/webserv_2/www
-            auth_basic jwon
-            auth_basic_user_file .htpasswd
+            root /Users/jwon/42/webserv/www
+            # auth_basic jwon
+            # auth_basic_user_file .htpasswd
             autoindex on
         }
         location /put_test {
             limit_except PUT
-            root /Users/jwon/42/webserv_2/tests/put_test
+            root /Users/jwon/42/webserv/tests/put_test
             cgi .bla
-            cgi_path /Users/jwon/42/webserv_2/cgi-bin/cgi_tester
+            cgi_path /Users/jwon/42/webserv/cgi-bin/cgi_tester
         }
         location /post_body {
             limit_body_size 100
             limit_except POST
             index index.html
-            # root /Users/jwon/42/webserv_2/tests/folder
+            # root /Users/jwon/42/webserv/tests/folder
         }
         location /directory {
             limit_except GET POST
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path /Users/jwon/42/webserv_2/YoupiBanane/youpi.bla
-            root /Users/jwon/42/webserv_2/YoupiBanane
+            cgi_path /Users/jwon/42/webserv/YoupiBanane/youpi.bla
+            root /Users/jwon/42/webserv/YoupiBanane
         }
     }
     server {

--- a/config/ftinx_tonybyeon.conf
+++ b/config/ftinx_tonybyeon.conf
@@ -1,6 +1,6 @@
 http {
-    software_name ftinx #프로그램명
-    software_version 0.1 #버전
+    software_name ftinx
+    software_version 0.1
     include mime.types
     default_type application/octet-stream
     root /Users/tonybyeon/Desktop/webserv/www

--- a/includes/Exception.hpp
+++ b/includes/Exception.hpp
@@ -23,23 +23,38 @@ class LocationBlockDoesNotExistException : public std::exception
 		virtual const char* what() const throw();
 };
 
-class BracketErrorException : public std::exception
-{
-	public:
-		virtual const char* what() const throw();
-};
-
 class MimeTypeErrorException : public std::exception
 {
 	public:
 		virtual const char* what() const throw();
 };
 
-class PathErrorException : public std::exception
+class BracketPairErrorException : public std::exception
 {
 	public:
 		virtual const char* what() const throw();
 };
 
+class BracketDoubleErrorException : public std::exception
+{
+	private:
+		std::string error_msg;
+		BracketDoubleErrorException();
+	public:
+		BracketDoubleErrorException(std::string line, size_t idx);
+		virtual ~BracketDoubleErrorException() throw();
+		virtual const char* what() const throw();
+};
+
+class PathErrorException : public std::exception
+{
+	private:
+		std::string error_msg;
+		PathErrorException();
+	public:
+		PathErrorException(std::string line, size_t idx);
+		virtual ~PathErrorException() throw();
+		virtual const char* what() const throw();
+};
 
 #endif

--- a/includes/HttpConfig.hpp
+++ b/includes/HttpConfig.hpp
@@ -52,14 +52,14 @@ class HttpConfig
 
 		/* setter */
 		void parseMimeTypes();
-		void setConfigFileCheckValid(std::string file_path);
+		void setConfigFileCheckValid(std::string &file_path);
 		void setDefaultRootPath();
 		// void setConfigFile();
 		// void setConfigLines();
 		// void checkValidHttpBlock();
 
 		/* key func. */
-		void parseConfigFile(std::string file_path);
+		void parseConfigFile(std::string &file_path);
 
 		/* debug */
 		void printConfigFileInfo();

--- a/includes/HttpConfig.hpp
+++ b/includes/HttpConfig.hpp
@@ -14,10 +14,8 @@
 class HttpConfig
 {
 	private:
-		std::string m_file_path;
 		std::string m_config_file; // config file -> string
 		std::vector<std::string> m_lines; // m_config_file -> split lines(\n)
-		int m_cnt_trash_lines; // for debug
 
 		std::string m_name;
 		std::string m_version;
@@ -29,11 +27,9 @@ class HttpConfig
 
 	private:
 		/* utils */
-		bool checkStartHttp(); // m_lines의 시작이 "http" 인지 여부 확인
-		bool checkBlankLine(std::string str);
 		bool checkCurlyBracketsFaired(); // 중괄호의 갯수와 열고 닫음에 에러가 없는지 확인
-		bool checkCurlyBracketsDouble(std::string str);
-
+		void parseMimeTypes();
+		void setDefaultRootPath();
 
 	public:
 		HttpConfig();
@@ -51,12 +47,6 @@ class HttpConfig
 		std::map<std::string, std::string> get_m_mime_types() const;
 
 		/* setter */
-		void parseMimeTypes();
-		void setConfigFileCheckValid(std::string &file_path);
-		void setDefaultRootPath();
-		// void setConfigFile();
-		// void setConfigLines();
-		// void checkValidHttpBlock();
 
 		/* key func. */
 		void parseConfigFile(std::string &file_path);

--- a/includes/HttpConfigLocation.hpp
+++ b/includes/HttpConfigLocation.hpp
@@ -41,16 +41,8 @@ class HttpConfigLocation
 		void set_m_root(std::string root);
 
 		/* utils */
-		static bool checkCommentLine(std::string str);
-		static void checkDirExist(std::string path);
-		static void checkFileExist(std::string root, std::string path);
 
 		/* exceptions */
-		class parseErrorException : public std::exception
-		{
-			public:
-				virtual const char *what() const throw();
-		};
 
 		/* key func. */
 		HttpConfigLocation& parseLocationBlock(std::vector<std::string> lines, std::string root, size_t &idx);

--- a/includes/HttpConfigServer.hpp
+++ b/includes/HttpConfigServer.hpp
@@ -28,7 +28,6 @@ class HttpConfigServer
 		const std::vector<HttpConfigLocation> get_m_location_block() const;
 
 		/* setter */
-
 		void set_m_root(std::string m_root);
 
 		/* key func. */

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -65,6 +65,7 @@ namespace ft
 	void doubleFree(char** str);
 
 	/* LIBFT C++ */
+	std::string strTolower(const std::string &str);
 	int stoi(const std::string &str);
 	char* strdup(const std::string &str);
 	std::string ltrim(const std::string &str, const std::string &set);
@@ -106,6 +107,11 @@ namespace ft
 	Method getMethodType(const std::string &str);
 	std::string getMethodString(const Method &method);
 	std::string getErrorMessage(int status_code);
+
+	/* PASRSE CONFIG */
+	bool checkBlankStr(std::string str);
+	bool checkCommentStr(std::string str);
+	bool checkCurlyBracketsDouble(std::string str);
 }
 
 #endif

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -19,7 +19,6 @@
 # define SOCK_BUFF 1000000
 # define RESV_SIZE 150000000
 
-
 enum Method
 {
 	DEFAULT,
@@ -63,6 +62,7 @@ namespace ft
 	void putnbr_fd(int n, int fd);
 	char* strchr(const char *str, int c);
 	void* memset(void *str, int c, size_t n);
+	void doubleFree(char** str);
 
 	/* LIBFT C++ */
 	int stoi(const std::string &str);
@@ -95,15 +95,16 @@ namespace ft
 	std::string encode(const std::string &input);
 	std::string decode(const std::string &input);
 
-	/* ETC */
-	void doubleFree(char** str);
+	/* FILE */
+	std::string fileToString(const std::string &file_path);
 	bool isValidFilePath(const std::string &path);
 	bool isValidDirPath(const std::string &path);
-	std::string fileToString(const std::string &file_path);
-	Method getMethodType(const std::string &str);
-	std::string getMethodString(const Method &method);
 	bool checkValidFileExtension(const std::string &file_name, const std::string &ext);
 	bool checkValidFileExtension(const std::string &file_name, const std::vector<std::string> &ext_list);
+
+	/* ETC */
+	Method getMethodType(const std::string &str);
+	std::string getMethodString(const Method &method);
 	std::string getErrorMessage(int status_code);
 }
 

--- a/run.sh
+++ b/run.sh
@@ -1,23 +1,36 @@
 #!/bin/bash
 
-clear
-echo -e "\033[47;30m* WELCOME TO FTINX :) *\033[0m"
-echo ""
-
-for config_file_list in `ls config`
+flag=1
+while [ ${flag} -eq 1 ]
 do
-        let I=I+1
-        echo "$I) $config_file_list"
+        clear
+        echo -e "\033[47;30m* WELCOME TO FTINX :) *\033[0m"
+        echo ""
+        I=0
+        for config_file_list in `ls config`
+        do
+                let I=I+1
+                echo "$I) $config_file_list"
+        done
+        echo -e "\033[40;33mIf you do not enter any number, the default server runs\033[0m"
+        echo ""
+        echo -n "SELECT CONFIG FILE : "
+        if [[ $# == 1 ]];then
+                selected_file_num="$1"
+        else
+                read selected_file_num
+        fi
+        # 인자가 입력된 경우 config 파일 숫자를 대체
+
+        for_check=${selected_file_num//[1-"$I"]/}
+        if [[ $for_check ]];then
+                flag=1
+        else
+                flag=0
+        fi
+        # 인자가 범위를 벗어나면 루프에 빠짐
 done
-echo -e "\033[40;33mIf you do not enter any number, the default server runs\033[0m"
-echo ""
-echo -n "SELECT CONFIG FILE : "
-if [[ $# == 1 ]];then
-        selected_file_num="$1"
-else
-        read selected_file_num
-fi
-# 인자가 입력된 경우 config 파일 숫자를 대체
+
 if [[ $selected_file_num == "" ]];then
         file_name="default.conf"
 else
@@ -38,7 +51,7 @@ echo ""
 make >& make.log
 # make 하며 내용을 make.log에 저장
 if [[ -z `grep "error" make.log` ]];then
-        echo "\033[47;30m* COMPILE SUCCESS *\033[0m"
+        echo -e "\033[47;30m* COMPILE SUCCESS *\033[0m"
 else
         echo -e "\033[41;30m* COMPILE ERROR *\033[0m"
         echo -e "\033[41;30m* -----------cat make.log----------- *\033[0m"

--- a/srcs/Exception.cpp
+++ b/srcs/Exception.cpp
@@ -7,35 +7,61 @@
 const char *
 HttpBlockDoesNotExistException::what() const throw()
 {
-	return ("Error: Http block does not exist");
+	return ("[Config] Http block does not exist");
 }
 
 const char *
 ServerBlockDoesNotExistException::what() const throw()
 {
-	return ("Error: Server block does not exist");
+	return ("[Config] Server block does not exist");
 }
 
 const char *
 LocationBlockDoesNotExistException::what() const throw()
 {
-	return ("Error: Location block does not exist");
-}
-
-const char *
-BracketErrorException::what() const throw()
-{
-	return ("Error: Bracket is mismatched or duplicated");
+	return ("[Config] Location block does not exist");
 }
 
 const char *
 MimeTypeErrorException::what() const throw()
 {
-	return ("Error: \"mime.types\" file must be included");
+	return ("[Config] \"mime.types\" file must be included");
 }
+
+const char *
+BracketPairErrorException::what() const throw()
+{
+	return ("[Config] Bracket must be paired");
+}
+
+const char *
+BracketDoubleErrorException::what() const throw()
+{
+	return (this->error_msg.c_str());
+}
+
+BracketDoubleErrorException::BracketDoubleErrorException(std::string line, size_t idx)
+{
+	this->error_msg += std::string("[Config] Bracket is duplicated -> (line:")
+		+ std::to_string(idx + 1)
+		+ std::string(") ")
+		+ line;
+}
+
+BracketDoubleErrorException::~BracketDoubleErrorException() throw() {}
 
 const char *
 PathErrorException::what() const throw()
 {
-	return ("Error: file or folder does not exist");
+	return (this->error_msg.c_str());
 }
+
+PathErrorException::PathErrorException(std::string line, size_t idx)
+{
+	this->error_msg += std::string("[Config] file or folder does not exist -> (line:")
+		+ std::to_string(idx + 1)
+		+ std::string(") ")
+		+ line;
+}
+
+PathErrorException::~PathErrorException() throw() {}

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -184,7 +184,7 @@ HttpConfig::parseMimeTypes()
 }
 
 void
-HttpConfig::setConfigFileCheckValid(std::string file_path)
+HttpConfig::setConfigFileCheckValid(std::string &file_path)
 {
 	size_t idx = 0;
 	this->m_cnt_trash_lines = 0;
@@ -222,7 +222,7 @@ HttpConfig::setDefaultRootPath()
 }
 
 void
-HttpConfig::parseConfigFile(std::string file_path)
+HttpConfig::parseConfigFile(std::string &file_path)
 {
 	size_t idx = 0;
 	bool server_block_exist = false;

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -179,6 +179,11 @@ HttpConfig::parseConfigFile(std::string &file_path)
 			idx++;
 			continue ;
 		}
+		if (this->m_lines[idx].find_first_of("#") != std::string::npos)
+		{
+			this->m_lines[idx].erase(this->m_lines[idx].find_first_of("#"));
+			this->m_lines[idx] = ft::rtrim(this->m_lines[idx], " ");
+		}
 		if (ft::checkCurlyBracketsDouble(this->m_lines[idx]))
 			throw BracketDoubleErrorException(m_lines[idx], idx);
 		line = ft::split(m_lines[idx], ' ');

--- a/srcs/HttpConfig.cpp
+++ b/srcs/HttpConfig.cpp
@@ -9,7 +9,7 @@ HttpConfig::HttpConfig()
 	m_name("ftinx"),
 	m_version("0.1"),
 	m_include(""),
-	m_default_type(""),
+	m_default_type("application/octet-stream"),
 	m_root(""),
 	m_server_block(),
 	m_mime_types()
@@ -102,25 +102,6 @@ HttpConfig::get_m_mime_types() const
 /*============================================================================*/
 
 bool
-HttpConfig::checkStartHttp()
-{
-	std::vector<std::string> first_line;
-
-	first_line = ft::split(m_lines[0], " ");
-	if (first_line[0].compare("http"))
-		return (false);
-	return (true);
-}
-
-bool
-HttpConfig::checkBlankLine(std::string str)
-{
-	if (str.empty() == false)
-		return (false);
-	return (true);
-}
-
-bool
 HttpConfig::checkCurlyBracketsFaired()
 {
 	std::stack<char> stack;
@@ -144,21 +125,6 @@ HttpConfig::checkCurlyBracketsFaired()
 	return (true);
 }
 
-bool
-HttpConfig::checkCurlyBracketsDouble(std::string str)
-{
-	int cnt = 0;
-
-	for (size_t i = 0 ; i < str.size() ; i++)
-	{
-		if (str[i] == '{' || str[i] == '}')
-			cnt++;
-		if (cnt > 1)
-			return (true);
-	}
-	return (false);
-}
-
 void
 HttpConfig::parseMimeTypes()
 {
@@ -167,7 +133,7 @@ HttpConfig::parseMimeTypes()
 
 	for (std::vector<std::string>::const_iterator it = lines.begin() ; it != lines.end() ; ++it)
 	{
-		if (checkBlankLine(*it) || it->find("{") != std::string::npos || it->find("}") != std::string::npos)
+		if (ft::checkBlankStr(*it) || it->find("{") != std::string::npos || it->find("}") != std::string::npos)
 			continue ;
 		std::vector<std::string> tmp = ft::split(ft::rtrim(ft::ltrim(*it, " "), ";"), " ");
 		std::string value = tmp.front();
@@ -184,35 +150,6 @@ HttpConfig::parseMimeTypes()
 }
 
 void
-HttpConfig::setConfigFileCheckValid(std::string &file_path)
-{
-	size_t idx = 0;
-	this->m_cnt_trash_lines = 0;
-	this->m_file_path = file_path;
-	this->m_config_file = ft::fileToString(m_file_path);
-	this->m_lines = ft::split(this->m_config_file, '\n');
-
-	while (idx < this->m_lines.size())
-	{
-		this->m_lines[idx] = ft::trim(this->m_lines[idx], " ");
-		if (checkCurlyBracketsDouble(this->m_lines[idx]))
-			throw BracketErrorException();
-		if (checkBlankLine(this->m_lines[idx]) ||
-			HttpConfigLocation::checkCommentLine(this->m_lines[idx]))
-		{
-			this->m_lines.erase(this->m_lines.begin() + idx);
-			this->m_cnt_trash_lines++;
-			continue ;
-		}
-		idx++;
-	}
-	if (checkStartHttp() == false)
-		throw HttpBlockDoesNotExistException();
-	if (checkCurlyBracketsFaired() == false)
-		throw BracketErrorException();
-}
-
-void
 HttpConfig::setDefaultRootPath()
 {
 	char path[1024];
@@ -225,43 +162,60 @@ void
 HttpConfig::parseConfigFile(std::string &file_path)
 {
 	size_t idx = 0;
+	std::vector<std::string> line;
+	bool http_block_exist = false;
 	bool server_block_exist = false;
+	this->m_config_file = ft::fileToString(file_path);
+	this->m_lines = ft::split(this->m_config_file, '\n');
 
 	setDefaultRootPath();
-	setConfigFileCheckValid(file_path);
+	if (HttpConfig::checkCurlyBracketsFaired() == false)
+		throw BracketPairErrorException();
 	while (idx < this->m_lines.size())
 	{
-		std::vector<std::string> line;
-		line.clear();
-		line = ft::split(m_lines[idx], ' ');
-		if (HttpConfigLocation::checkCommentLine(line.back()))
-			line.pop_back();
-		if (line.front().compare("software_name") == 0)
-			this->m_name = line.back();
-		else if (line.front().compare("software_version") == 0)
-			this->m_version = line.back();
-		else if (line.front().compare("include") == 0)
+		this->m_lines[idx] = ft::trim(this->m_lines[idx], " ");
+		if (ft::checkBlankStr(this->m_lines[idx]) || ft::checkCommentStr(this->m_lines[idx]))
 		{
-			this->m_include = line.back();
-			if (ft::checkValidFileExtension(this->m_include, "types"))
-				parseMimeTypes();
-		}
-		else if (line.front().compare("default_type") == 0)
-			this->m_default_type =  line.back();
-		else if (line.front().compare("root") == 0)
-		{
-			HttpConfigLocation::checkDirExist(line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
-			this->m_root = line.back();
-		}
-		else if (line.front().compare("server") == 0)
-		{
-			server_block_exist = true;
-			HttpConfigServer server = HttpConfigServer();
-			this->m_server_block.push_back(server.parseServerBlock(this->m_lines, this->m_root, idx));
+			idx++;
 			continue ;
 		}
-		else if (line.front().compare("}") == 0)
-			break ;
+		if (ft::checkCurlyBracketsDouble(this->m_lines[idx]))
+			throw BracketDoubleErrorException(m_lines[idx], idx);
+		line = ft::split(m_lines[idx], ' ');
+		if (http_block_exist == false && line.front().compare("http") == 0)
+			http_block_exist = true;
+		else
+		{
+			if (http_block_exist == false)
+				throw HttpBlockDoesNotExistException();
+			if (line.front().compare("software_name") == 0)
+				this->m_name = line.back();
+			else if (line.front().compare("software_version") == 0)
+				this->m_version = line.back();
+			else if (line.front().compare("include") == 0)
+			{
+				this->m_include = line.back();
+				if (ft::checkValidFileExtension(this->m_include, "types"))
+					parseMimeTypes();
+			}
+			else if (line.front().compare("default_type") == 0)
+				this->m_default_type =  line.back();
+			else if (line.front().compare("root") == 0)
+			{
+				if (ft::isValidDirPath(line.back()) == false)
+					throw PathErrorException(m_lines[idx], idx);
+				this->m_root = line.back();
+			}
+			else if (line.front().compare("server") == 0)
+			{
+				server_block_exist = true;
+				HttpConfigServer server = HttpConfigServer();
+				this->m_server_block.push_back(server.parseServerBlock(this->m_lines, this->m_root, idx));
+				continue ;
+			}
+			else if (line.front().compare("}") == 0)
+				break ;
+		}
 		idx++;
 	}
 	if (server_block_exist == false)
@@ -277,9 +231,9 @@ HttpConfig::printConfigFileInfo()
 
 	std::cout << dash << std::endl
 		<< "config file infomation" << std::endl
-		<< "path(relative) : " << this->m_file_path << std::endl
+		// << "path(relative) : " << this->m_file_path << std::endl
 		<< "size: " << this->m_config_file.size() << " bytes, "
-		<< this->m_lines.size() + this->m_cnt_trash_lines << " lines" << std::endl
+		// << this->m_lines.size() + this->m_cnt_trash_lines << " lines" << std::endl
 		<< dash << std::endl
 		<< std::endl;
 

--- a/srcs/HttpConfigLocation.cpp
+++ b/srcs/HttpConfigLocation.cpp
@@ -127,46 +127,23 @@ HttpConfigLocation::set_m_root(std::string root)
 /*********************************  Util  *************************************/
 /*============================================================================*/
 
-bool
-HttpConfigLocation::checkCommentLine(std::string str)
-{
-	if (str.find("#") != 0)
-		return (false);
-	return (true);
-}
-
-void
-HttpConfigLocation::checkDirExist(std::string path)
-{
-	if (ft::isValidDirPath(path) == false)
-		throw PathErrorException();
-}
-
-void
-HttpConfigLocation::checkFileExist(std::string root, std::string path)
-{
-	if (root != "") // 상대경로라면 root와 path 결합 후 유효성체크
-	{
-		if (ft::isValidFilePath(root + path.substr(2, path.length())) == false)
-			throw PathErrorException();
-	}
-	else // 절대경로라면 path 유효성 체크
-	{
-		if (ft::isValidFilePath(path) == false)
-			throw PathErrorException();
-	}
-}
-
 HttpConfigLocation&
 HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::string root, size_t &idx)
 {
+	std::vector<std::string> line;
+
 	while (42)
 	{
-		std::vector<std::string> line;
+		lines[idx] = ft::trim(lines[idx], " ");
+		if (ft::checkBlankStr(lines[idx]) || ft::checkCommentStr(lines[idx]))
+		{
+			idx++;
+			continue ;
+		}
+		if (ft::checkCurlyBracketsDouble(lines[idx]))
+			throw BracketDoubleErrorException(lines[idx], idx);
 		line.clear();
 		line = ft::split(lines[idx], ' ');
-		if (checkCommentLine(line.back()))
-			line.pop_back();
 		if (line.front().compare("location") == 0)
 		{
 			for (size_t i = 1 ; i < line.size() ; i++)
@@ -188,7 +165,8 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::stri
 		}
 		else if (line.front().compare("root") == 0)
 		{
-			checkDirExist(line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
+			if (ft::isValidDirPath(line.back()) == false)
+				throw PathErrorException(lines[idx], idx);
 			this->m_root = line.back();
 		}
 		else if (line.front().compare("index") == 0)
@@ -206,13 +184,13 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::stri
 			{
 				if (line[i].empty())
 					continue ;
-				// if (checkCgiFormat(line[i])) // cgi 포맷 체크
 				this->m_cgi.push_back(line[i]);
 			}
 		}
 		else if (line.front().compare("cgi_path") == 0)
 		{
-			checkFileExist("", line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
+			if (ft::isValidFilePath(line.back()) == false)
+				throw PathErrorException(lines[idx], idx);
 			this->m_cgi_path = line.back();
 		}
 		else if (line.front().compare("autoindex") == 0)
@@ -233,14 +211,12 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::stri
 		}
 		else if (line.front().compare("auth_basic_user_file") == 0)
 		{
+			if (ft::isValidFilePath(root + std::string("/") + line.back()) == false)
+				throw PathErrorException(lines[idx], idx);
 			this->m_auth_basic_user_file = line.back();
 		}
 		else if (line.front().compare("limit_body_size") == 0)
-		{
 			this->m_limit_body_size = ft::stoi(line.back());
-			if (this->m_limit_body_size == 0)
-				this->m_limit_body_size = INT_MAX;
-		}
 		else if (line.front().compare("}") == 0)
 		{
 			idx++;

--- a/srcs/HttpConfigLocation.cpp
+++ b/srcs/HttpConfigLocation.cpp
@@ -140,6 +140,11 @@ HttpConfigLocation::parseLocationBlock(std::vector<std::string> lines, std::stri
 			idx++;
 			continue ;
 		}
+		if (lines[idx].find_first_of("#") != std::string::npos)
+		{
+			lines[idx].erase(lines[idx].find_first_of("#"));
+			lines[idx] = ft::rtrim(lines[idx], " ");
+		}
 		if (ft::checkCurlyBracketsDouble(lines[idx]))
 			throw BracketDoubleErrorException(lines[idx], idx);
 		line.clear();

--- a/srcs/HttpConfigServer.cpp
+++ b/srcs/HttpConfigServer.cpp
@@ -98,6 +98,11 @@ HttpConfigServer::parseServerBlock(std::vector<std::string> lines, std::string r
 			idx++;
 			continue ;
 		}
+		if (lines[idx].find_first_of("#") != std::string::npos)
+		{
+			lines[idx].erase(lines[idx].find_first_of("#"));
+			lines[idx] = ft::rtrim(lines[idx], " ");
+		}
 		if (ft::checkCurlyBracketsDouble(lines[idx]))
 			throw BracketDoubleErrorException(lines[idx], idx);
 		line.clear();

--- a/srcs/HttpConfigServer.cpp
+++ b/srcs/HttpConfigServer.cpp
@@ -87,23 +87,29 @@ HttpConfigServer::get_m_location_block() const
 HttpConfigServer&
 HttpConfigServer::parseServerBlock(std::vector<std::string> lines, std::string root, size_t &idx)
 {
-	(void) root;
+	std::vector<std::string> line;
 	bool location_block_exist = false;
 
 	while (42)
 	{
-		std::vector<std::string> line;
+		lines[idx] = ft::trim(lines[idx], " ");
+		if (ft::checkBlankStr(lines[idx]) || ft::checkCommentStr(lines[idx]))
+		{
+			idx++;
+			continue ;
+		}
+		if (ft::checkCurlyBracketsDouble(lines[idx]))
+			throw BracketDoubleErrorException(lines[idx], idx);
 		line.clear();
 		line = ft::split(lines[idx], ' ');
-		if (HttpConfigLocation::checkCommentLine(line.back()))
-			line.pop_back();
 		if (line.front().compare("server_name") == 0)
 			this->m_server_name = line.back();
 		else if (line.front().compare("listen") == 0)
 			this->m_listen = stoi(line.back());
 		else if (line.front().compare("default_error_page") == 0)
 		{
-			// HttpConfigLocation::checkFileExist(root, line.back()); // 유효성 체크, 유연한 테스트를 위해 주석처리
+			if (ft::isValidFilePath(root + line.back()) == false)
+				throw PathErrorException(lines[idx], idx);
 			this->m_default_error_page = line.back();
 		}
 		else if (line.front().compare("content_length") == 0)

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -529,15 +529,6 @@ Request::parseRequestLine(std::string request_line)
 	return (true);
 }
 
-std::string
-strTolower(const std::string& str)
-{
-	std::string result;
-	for (size_t j = 0; j < str.length(); j++)
-		result += tolower(str[j]);
-	return (result);
-}
-
 bool
 Request::parseHeader(std::string line)
 {
@@ -563,13 +554,13 @@ Request::parseHeader(std::string line)
 		this->m_error_code = 400;
 		return (false);
 	}
-	if (strTolower(key_value[0]) == "host")
+	if (ft::strTolower(key_value[0]) == "host")
 		this->m_uri.set_m_host(ft::trim(key_value[1], " "));
-	else if (strTolower(key_value[0]) == "port")
+	else if (ft::strTolower(key_value[0]) == "port")
 		this->m_uri.set_m_port(ft::trim(key_value[1], " "));
 
-	if (this->m_headers.insert(make_pair(strTolower(key_value[0]), ft::trim(key_value[1], " "))).second == false
-	&& strTolower(key_value[0]) == "host")
+	if (this->m_headers.insert(make_pair(ft::strTolower(key_value[0]), ft::trim(key_value[1], " "))).second == false
+	&& ft::strTolower(key_value[0]) == "host")
 	{
 		this->m_error_code = 400;
 		return (false);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -701,7 +701,7 @@ Server::resetRequest(Request *req)
 	if (block.get_m_auth_basic().empty() == false) // 인증이 필요한 블럭일 때
 	{
 		std::map<std::string, std::string> headers = req->get_m_headers();
-		std::map<std::string, std::string>::const_iterator header_it = headers.find("Authorization");
+		std::map<std::string, std::string>::const_iterator header_it = headers.find("authorization");
 		if (header_it == headers.end()) // 인증 헤더가 없으면 401 에러
 		{
 			req->set_m_error_code(401);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1220,7 +1220,7 @@ Server::methodPOST(int clientfd, std::string method)
 Response
 Server::methodPUT(int clientfd, std::string method)
 {
-	Request req = this->m_requests[clientfd];
+	Request &req(this->m_requests[clientfd]);
 	std::string path = req.get_m_reset_path();
 
 	int fd;
@@ -1260,7 +1260,8 @@ Server::methodPUT(int clientfd, std::string method)
 Response
 Server::methodDELETE(int clientfd, std::string method)
 {
-	std::string path = m_requests[clientfd].get_m_reset_path();
+	Request &req(this->m_requests[clientfd]);
+	std::string path = req.get_m_reset_path();
 
 	if (ft::isValidFilePath(path))
 	{

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -146,6 +146,18 @@ memset(void *str, int c, size_t n)
 	return (str);
 }
 
+void
+doubleFree(char **str)
+{
+	int i(0);
+
+	while(str[i] == 0)
+	{
+		free(str[i++]);
+	}
+	free(str);
+}
+
 /*============================================================================*/
 /*******************************  Libft C++  **********************************/
 /*============================================================================*/
@@ -361,18 +373,6 @@ iNetNtoA(unsigned int addr)
 /*******************************  TIME  ***************************************/
 /*============================================================================*/
 
-void
-doubleFree(char **str)
-{
-	int i(0);
-
-	while(str[i] == 0)
-	{
-		free(str[i++]);
-	}
-	free(str);
-}
-
 std::string
 getDateTimestamp(int hour, int minute, int second)
 {
@@ -495,8 +495,27 @@ decode(const std::string &input)
 }
 
 /*============================================================================*/
-/*******************************  ETC  ****************************************/
+/*******************************  FILE  ***************************************/
 /*============================================================================*/
+
+std::string
+fileToString(const std::string &file_path)
+{
+	int fd;
+	int bytes;
+	char buffer[BUFFER_SIZE];
+	std::string ret("");
+
+	if ((fd = open(file_path.c_str(), O_RDONLY)) < 0)
+		throw std::exception();
+	ft::memset(reinterpret_cast<void *>(buffer), 0, BUFFER_SIZE);
+	while ((bytes = read(fd, reinterpret_cast<void *>(buffer), BUFFER_SIZE - 1)) > 0)
+		ret += std::string(buffer, bytes);
+	if (bytes < 0)
+		throw std::exception();
+	close(fd);
+	return (ret);
+}
 
 bool
 isValidFilePath(const std::string &path)
@@ -522,24 +541,44 @@ isValidDirPath(const std::string &path)
 	return (false); // 폴더가 아님
 }
 
-std::string
-fileToString(const std::string &file_path)
+bool
+checkValidFileExtension(const std::string &file_name, const std::string &ext)
 {
-	int fd;
-	int bytes;
-	char buffer[BUFFER_SIZE];
-	std::string ret("");
+	std::vector<std::string> tmp;
+	std::string extension;
 
-	if ((fd = open(file_path.c_str(), O_RDONLY)) < 0)
-		throw std::exception();
-	ft::memset(reinterpret_cast<void *>(buffer), 0, BUFFER_SIZE);
-	while ((bytes = read(fd, reinterpret_cast<void *>(buffer), BUFFER_SIZE - 1)) > 0)
-		ret += std::string(buffer, bytes);
-	if (bytes < 0)
-		throw std::exception();
-	close(fd);
-	return (ret);
+	if (file_name.find_last_of(".") == std::string::npos)
+		return (false);
+	tmp = ft::split(file_name, '.');
+	extension = tmp.back();
+	if (ext.compare(extension) == 0)
+		return (true);
+	return (false);
 }
+
+bool
+checkValidFileExtension(const std::string &file_name, const std::vector<std::string> &ext_list)
+{
+	std::vector<std::string>::const_iterator it;
+	std::string extension;
+	size_t pos;
+
+	if ((pos = file_name.find_last_of(".")) == std::string::npos)
+		return (false);
+	extension = file_name.substr(pos, std::string::npos);
+	if ((pos = extension.find_first_of("/")) != std::string::npos)
+		extension = extension.substr(0, pos);
+	for (it = ext_list.begin() ; it != ext_list.end() ; it++)
+	{
+		if (*it == extension)
+			return (true);
+	}
+	return (false);
+}
+
+/*============================================================================*/
+/*******************************  ETC  ****************************************/
+/*============================================================================*/
 
 Method
 getMethodType(const std::string &str)
@@ -579,41 +618,6 @@ getMethodString(const Method &method)
 	else if (method == TRACE)
 		return ("TRACE");
 	return ("DEFAULT");
-}
-
-bool
-checkValidFileExtension(const std::string &file_name, const std::string &ext)
-{
-	std::vector<std::string> tmp;
-	std::string extension;
-
-	if (file_name.find_last_of(".") == std::string::npos)
-		return (false);
-	tmp = ft::split(file_name, '.');
-	extension = tmp.back();
-	if (ext.compare(extension) == 0)
-		return (true);
-	return (false);
-}
-
-bool
-checkValidFileExtension(const std::string &file_name, const std::vector<std::string> &ext_list)
-{
-	std::vector<std::string>::const_iterator it;
-	std::string extension;
-	size_t pos;
-
-	if ((pos = file_name.find_last_of(".")) == std::string::npos)
-		return (false);
-	extension = file_name.substr(pos, std::string::npos);
-	if ((pos = extension.find_first_of("/")) != std::string::npos)
-		extension = extension.substr(0, pos);
-	for (it = ext_list.begin() ; it != ext_list.end() ; it++)
-	{
-		if (*it == extension)
-			return (true);
-	}
-	return (false);
 }
 
 std::string

--- a/srcs/Utils.cpp
+++ b/srcs/Utils.cpp
@@ -162,6 +162,15 @@ doubleFree(char **str)
 /*******************************  Libft C++  **********************************/
 /*============================================================================*/
 
+std::string
+strTolower(const std::string& str)
+{
+	std::string result;
+	for (size_t j = 0; j < str.length(); j++)
+		result += tolower(str[j]);
+	return (result);
+}
+
 int
 stoi(const std::string &str)
 {
@@ -710,6 +719,41 @@ getErrorMessage(int status_code)
 		default:
 			return (std::string("Undefined Status Code"));
 	}
+}
+
+/*============================================================================*/
+/*******************************  PASRSE CONFIG  ******************************/
+/*============================================================================*/
+
+bool
+checkBlankStr(std::string str)
+{
+	if (str.empty() == false)
+		return (false);
+	return (true);
+}
+
+bool
+checkCommentStr(std::string str)
+{
+	if (str.substr(0, 1) != "#")
+		return (false);
+	return (true);
+}
+
+bool
+checkCurlyBracketsDouble(std::string str)
+{
+	int cnt = 0;
+
+	for (size_t i = 0 ; i < str.size() ; i++)
+	{
+		if (str[i] == '{' || str[i] == '}')
+			cnt++;
+		if (cnt > 1)
+			return (true);
+	}
+	return (false);
 }
 
 }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -42,7 +42,7 @@ main(int argc, char *argv[])
 	}
 	catch (const std::exception& e)
 	{
-		std::cerr << "[Err] main.c: " << e.what() << std::endl;
+		std::cerr << "Error: " << e.what() << std::endl;
 		return (EXIT_FAILURE);
 	}
 	serverManager.runServers();


### PR DESCRIPTION
- Utils.cpp,hpp 정리

- config 파일 파싱 관련
  - 에러 체크를 위해 파일 전체를 2번 순회하던걸 1번 순회하며 체크, 파싱 같이 하도록 수정
  - 주석만으로 이루어진 라인, 파싱해야 할 요소 뒤에 주석이 붙은 라인 모두 처리
  - http, server, location 파싱에서 공용으로 사용하는 함수 utils로 이동
  - strTolower 함수 utils로 이동

- 관련 exception 수정
  - 중괄호 에러, 파일 또는 폴더 경로가 정확하지 않은 경우 에러와 함께 해당 라인 체크 가능하도록 수정
    <img width="791" src="https://user-images.githubusercontent.com/61400214/114276447-8f343280-9a61-11eb-8b73-39093b9e757b.png">

- 인증관련 오류 있어서 고치는중.. -> 고침
  - https://github.com/ftinx/webserv/pull/287#issuecomment-817142996

- run.sh 수정
  - config 인덱스에 벗어나는 숫자 또는 문자가 입력될 경우 루프에 빠짐(재입력 요구)