### PR TITLE
[FIX] trace no req.m_message

### DIFF
--- a/.auth/.htpasswd_tonybyeon
+++ b/.auth/.htpasswd_tonybyeon
@@ -1,0 +1,1 @@
+dG9ueWJ5ZW9uOjAyMjI=

--- a/config/.sample.conf
+++ b/config/.sample.conf
@@ -44,6 +44,13 @@ http {
             cgi_path PWD/cgi-bin/cgi_tester
             root PWD/YoupiBanane
         }
+        location /trace {
+            limit_except TRACE
+            index youpi.bad_extension
+            cgi .bla .php
+            cgi_path PWD/cgi-bin/cgi_tester
+            root PWD/YoupiBanane
+        }
     }
     server {
         server_name second_server

--- a/config/tonybyeon.conf
+++ b/config/tonybyeon.conf
@@ -3,7 +3,7 @@ http {
     software_version 0.1
     include mime.types
     default_type application/octet-stream
-    root PWD/www
+    root /Users/tonybyeon/Desktop/webserv/www
     server {
         server_name first_server
         listen 8080
@@ -12,37 +12,44 @@ http {
         location / {
             limit_except GET
             cgi .bin .cgi .bla
-            cgi_path PWD/cgi-bin/cgi_tester
+            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/cgi_tester
             index index.html
-            root PWD/www
-            # auth_basic AUTHID
-            # auth_basic_user_file ../.auth/.htpasswd_AUTHID
+            root /Users/tonybyeon/Desktop/webserv/www
+            # auth_basic tonybyeon
+            # auth_basic_user_file ../.auth/.htpasswd_tonybyeon
             autoindex on
         }
         location /put_test {
             limit_except PUT
-            root PWD/tests/put_test
+            root /Users/tonybyeon/Desktop/webserv/tests/put_test
             cgi .bla
-            cgi_path PWD/cgi-bin/cgi_tester
+            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/cgi_tester
         }
         location /post_body {
             limit_body_size 100
             limit_except POST
-            root PWD/tests
+            root /Users/tonybyeon/Desktop/webserv/tests
         }
         location /directory {
             limit_except GET POST
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path PWD/cgi-bin/cgi_tester
-            root PWD/YoupiBanane
+            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/cgi_tester
+            root /Users/tonybyeon/Desktop/webserv/YoupiBanane
         }
         location /options {
             limit_except OPTIONS
             index youpi.bad_extension
             cgi .bla .php
-            cgi_path PWD/cgi-bin/cgi_tester
-            root PWD/YoupiBanane
+            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/cgi_tester
+            root /Users/tonybyeon/Desktop/webserv/YoupiBanane
+        }
+        location /trace {
+            limit_except TRACE
+            index youpi.bad_extension
+            cgi .bla .php
+            cgi_path /Users/tonybyeon/Desktop/webserv/cgi-bin/cgi_tester
+            root /Users/tonybyeon/Desktop/webserv/YoupiBanane
         }
     }
     server {

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -408,7 +408,6 @@ Request::getReferer()
 	/* `Referer` header not exist */
 	if (it == this->m_headers.end())
 		return ("");
-	std::cout << it->second << std::endl;
 	return (this->m_referer = it->second);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1380,7 +1380,7 @@ Server::methodTRACE(int clientfd, std::string method)
 	Response response = Response();
 
 	return (
-		Server::makeResponseBodyMessage(200, this->m_requests[clientfd].get_m_message(), "", "", method, "message/http", this->m_requests[clientfd].getReferer())
+		Server::makeResponseBodyMessage(200, this->m_server_name, this->m_requests[clientfd].get_m_raw_header() + this->m_requests[clientfd].get_m_body(), "", "", method, "message/http", this->m_requests[clientfd].getReferer())
 	);
 }
 


### PR DESCRIPTION
- 수정사항
  - request의 m_message가 사라짐에 따른 로직 변경 
  - options 일경우 methodOption 함수내에서 404,204,405 결정
  - trace 일경우 methodTrace 함수내에서 404,204,405 결정
  - config file options, trace default 추가

- 이제 아래 테스트 케이스를 처리할 수 있습니다.
https://github.com/ftinx/webserv_tester/blob/main/testcase.md