### PR TITLE
 [FIX] double Cgi request

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -626,7 +626,7 @@ Request::getBody(int fd)
 		/* 읽어오려고 했던 만큼 온전히 다 읽었을 때 */
 		if (ret == m_content_length)
 		{
-			std::cout << "hi1"<< std::endl;
+			std::cout << "hi1 "<< buff << std::endl;
 			m_body.append(buff);
 			m_read_end = true;
 			free(buff);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -529,6 +529,7 @@ Server::writeProcess()
 					}
 					else
 						request.set_m_body(body.substr(ret, std::string::npos));
+					ft::fdSet(request.get_m_cgi_stdin(), m_read_fds);
 				}
 				else if (ret < 0)
 				{
@@ -549,9 +550,11 @@ Server::writeProcess()
 				}
 				if (buffsize == 0 && ret == 0 && (request.get_m_read_end() == true))
 				{
+					std::cout << "::2:: chunked cgi write end" <<  tmp << std::endl;
 					pid_t ret;
 					write(request.get_m_check_fd(), "end", 3);
 					ret = waitpid(request.get_m_cgi_pid(), &status, 0);
+					std::cout << "waitpid ret: " << ret  << " " << request.get_m_cgi_pid() << std::endl;
 					ft::fdSet(request.get_m_cgi_stdin(), m_main_fds);
 					m_responses[fd_iter->clientfd].set_m_cgi_chunked_write_end(true);
 					ft::fdClr(sockfd, this->m_write_fds);
@@ -1218,8 +1221,8 @@ Server::executeCgi(Request &req, Response &res, int clientfd)
 
 	int parent_write = open(TMP2, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	int cgi_stdin = open(TMP2, O_RDONLY);
-	int parent_read = open(TMP1, O_RDONLY);
 	int cgi_stdout = open(TMP1, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	int parent_read = open(TMP1, O_RDONLY);
 
 
 	/* set fd nonblock */
@@ -1233,6 +1236,8 @@ Server::executeCgi(Request &req, Response &res, int clientfd)
 
 	int checkfd = open(CHECKFD, O_RDWR | O_CREAT | O_TRUNC, 0666);
 	std::cout << "checkfd: " << checkfd << std::endl;
+	std::cout << "parent_write: " << parent_write << std::endl;
+	std::cout << "parent_read: " << parent_read << std::endl;
 	req.set_m_check_fd(checkfd);
 	pid = fork();
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -141,7 +141,7 @@ ServerManager::runServers()
 	int fd_num = 0;
 
 	struct timeval timeout;
-	timeout.tv_sec = 1;
+	timeout.tv_sec = 4;
 	timeout.tv_usec = 2;
 
 	signal(SIGINT, exitServers);


### PR DESCRIPTION
두개 연달아 cgi 요청했을 때, 관련 fd가 -1 나오는 게 있었는데 open의 순서 문제였어요.

```
	int cgi_stdout = open(TMP1, O_WRONLY | O_CREAT | O_TRUNC, 0666);
	int parent_read = open(TMP1, O_RDONLY);
```
이게 바꾼거... 일단 O_CREAT | O_TRUNC 옵션이 있는게 먼저 와야함. 


```
	int parent_read = open(TMP1, O_RDONLY);
	int cgi_stdout = open(TMP1, O_WRONLY | O_CREAT | O_TRUNC, 0666);
```
이렇게 하면 parent_read에서 -1 뜹니다... 